### PR TITLE
Use FFI to perform paycall multi-step simulation

### DIFF
--- a/src/builder/QuarkBuilderBase.sol
+++ b/src/builder/QuarkBuilderBase.sol
@@ -95,6 +95,9 @@ contract QuarkBuilderBase {
     )
         internal
         view
+        // TODO: Perhaps this should also return the simulation so we don't have to do that again from the client side. 
+        // However, we will need to resimulate on the client on an interval anyway, so I'm not sure. Perhaps we expose another function
+        // that just takes quark operations array, actions array and payment that does the resimulation
         returns (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray)
     {
         if (!payment.isToken) {

--- a/src/builder/actions/Actions.sol
+++ b/src/builder/actions/Actions.sol
@@ -68,6 +68,9 @@ library Actions {
     uint256 constant RECURRING_SWAP_MAX_SLIPPAGE = 1e17; // 1%
     uint256 constant RECURRING_SWAP_WINDOW_LENGTH = 1 days;
 
+    /* FFI Addresses (starts from 0xFF1000, FFI with 100 reserved addresses) */
+    address constant SIMULATE_FFI_ADDRESS = address(0xFF1001);
+
     /* ===== Custom Errors ===== */
 
     error BridgingUnsupportedForAsset();

--- a/src/builder/actions/TransferActionsBuilder.sol
+++ b/src/builder/actions/TransferActionsBuilder.sol
@@ -31,7 +31,7 @@ contract TransferActionsBuilder is QuarkBuilderBase {
         TransferIntent memory transferIntent,
         Accounts.ChainAccounts[] memory chainAccountsList,
         PaymentInfo.Payment memory payment
-    ) external pure returns (BuilderResult memory) {
+    ) external view returns (BuilderResult memory) {
         // If the action is paid for with tokens, filter out any chain accounts that do not have corresponding payment information
         if (payment.isToken) {
             chainAccountsList = Accounts.findChainAccountsWithPaymentInfo(chainAccountsList, payment);
@@ -86,7 +86,7 @@ contract TransferActionsBuilder is QuarkBuilderBase {
         }
 
         (IQuarkWallet.QuarkOperation[] memory quarkOperationsArray, Actions.Action[] memory actionsArray) =
-        collectAssetsForAction({
+        simulateAndGetActions({
             actionIntent: actionIntent,
             chainAccountsList: chainAccountsList,
             payment: payment,


### PR DESCRIPTION
Currently, the logic for multi-step simulation for paycall transactions is all done on the client side. This PR aims to move this logic into QuarkBuilder by making a call to a simulation ffi. ie. when calling the builder with an intent which uses paycall, the builder first simulates the transaction to get the estimated max payment cost and then uses the estimate for building up the transaction with paycall

CC @banky 