### PR TITLE
Add BridgeAmountTooLow error

### DIFF
--- a/src/builder/Errors.sol
+++ b/src/builder/Errors.sol
@@ -5,4 +5,5 @@ pragma solidity 0.8.27;
 library Errors {
     error BadData();
     error NoKnownBridge(string bridgeType, uint256 srcChainId);
+    error BridgeAmountTooLow();
 }

--- a/src/builder/QuarkBuilderBase.sol
+++ b/src/builder/QuarkBuilderBase.sol
@@ -7,6 +7,7 @@ import {Actions} from "src/builder/actions/Actions.sol";
 import {Accounts} from "src/builder/Accounts.sol";
 import {Across, BridgeRoutes} from "src/builder/BridgeRoutes.sol";
 import {EIP712Helper} from "src/builder/EIP712Helper.sol";
+import {Errors} from "src/builder/Errors.sol";
 import {Math} from "src/lib/Math.sol";
 import {MorphoInfo} from "src/builder/MorphoInfo.sol";
 import {Strings} from "src/builder/Strings.sol";
@@ -18,7 +19,7 @@ import {QuarkOperationHelper} from "src/builder/QuarkOperationHelper.sol";
 import {List} from "src/builder/List.sol";
 import {HashMap} from "src/builder/HashMap.sol";
 
-string constant QUARK_BUILDER_VERSION = "0.3.1";
+string constant QUARK_BUILDER_VERSION = "0.3.2";
 
 contract QuarkBuilderBase {
     /* ===== Output Types ===== */
@@ -683,5 +684,14 @@ contract QuarkBuilderBase {
         }
 
         return amountNeededOnChain;
+    }
+
+    // Stub to ensure that unused errors make it in the ABI
+    function includeErrors() external pure returns (uint256) {
+        if (true) {
+            return 0;
+        } else {
+            revert Errors.BridgeAmountTooLow();
+        }
     }
 }


### PR DESCRIPTION
Defines a `BridgeAmountTooLow` custom error that will be used by the client.