### PR TITLE
QuarkBuilder 0.4.0 (QuotePay support) 

### DIFF
--- a/src/QuotePay.sol
+++ b/src/QuotePay.sol
@@ -18,7 +18,7 @@ contract QuotePay {
 
     /**
      * @notice Pay the payee the quoted amount of the payment token
-     * @param payee The token used to pay for this transaction
+     * @param payee The receiver of this payment
      * @param paymentToken The token used to pay for this transaction
      * @param quotedAmount The quoted network fee for this transaction, in units of the payment token
      * @param quoteId The identifier of the quote that is being paid

--- a/src/QuotePay.sol
+++ b/src/QuotePay.sol
@@ -23,7 +23,7 @@ contract QuotePay {
      * @param quotedAmount The quoted network fee for this transaction, in units of the payment token
      * @param quoteId The identifier of the quote that is being paid
      */
-    function run(address payee, address paymentToken, uint256 quotedAmount, bytes32 quoteId) external {
+    function pay(address payee, address paymentToken, uint256 quotedAmount, bytes32 quoteId) external {
         IERC20(paymentToken).safeTransfer(payee, quotedAmount);
         emit PayQuote(address(this), payee, paymentToken, quotedAmount, quoteId);
     }

--- a/src/builder/HashMap.sol
+++ b/src/builder/HashMap.sol
@@ -30,6 +30,18 @@ library HashMap {
         revert KeyNotFound();
     }
 
+    function getOrDefault(Map memory map, bytes memory key, bytes memory fallbackValue)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        if (contains(map, key)) {
+            return get(map, key);
+        } else {
+            return fallbackValue;
+        }
+    }
+
     function contains(Map memory map, bytes memory key) internal pure returns (bool) {
         for (uint256 i = 0; i < map.entries.length; ++i) {
             Entry memory entry = abi.decode(List.get(map.entries, i), (Entry));
@@ -96,8 +108,21 @@ library HashMap {
         return abi.decode(get(map, key), (uint256));
     }
 
+    function getOrDefaultUint256(Map memory map, bytes memory key, uint256 fallbackValue)
+        internal
+        pure
+        returns (uint256)
+    {
+        return abi.decode(getOrDefault(map, key, abi.encode(fallbackValue)), (uint256));
+    }
+
     function putUint256(Map memory map, bytes memory key, uint256 value) internal pure returns (Map memory) {
         return put(map, key, abi.encode(value));
+    }
+
+    function addOrPutUint256(Map memory map, bytes memory key, uint256 value) internal pure returns (Map memory) {
+        uint256 existingValue = getOrDefaultUint256(map, key, 0);
+        return HashMap.putUint256(map, key, existingValue + value);
     }
 
     function keysUint256(Map memory map) internal pure returns (uint256[] memory) {

--- a/src/builder/PaymentInfo.sol
+++ b/src/builder/PaymentInfo.sol
@@ -17,8 +17,8 @@ library PaymentInfo {
         // Note: Payment `currency` should be the same across chains
         string currency;
         // Note: If quote is not specified for a chain when paying with token, then that chain is ignored
-        // TODO: Treat PaymentMaxCost as Quote for now. Rename later
         bytes32 quoteId;
+        // TODO: Rename to something more fitting (e.g. `quote`)
         PaymentMaxCost[] maxCosts;
     }
 

--- a/src/builder/PaymentInfo.sol
+++ b/src/builder/PaymentInfo.sol
@@ -16,7 +16,9 @@ library PaymentInfo {
         bool isToken;
         // Note: Payment `currency` should be the same across chains
         string currency;
-        // Note: If max cost is not specified for a chain when paying with token, then that chain is ignored
+        // Note: If quote is not specified for a chain when paying with token, then that chain is ignored
+        // TODO: Treat PaymentMaxCost as Quote for now. Rename later
+        bytes32 quoteId;
         PaymentMaxCost[] maxCosts;
     }
 
@@ -85,6 +87,14 @@ library PaymentInfo {
             }
         }
         revert MaxCostMissingForChain(chainId);
+    }
+
+    function totalCost(Payment memory payment, uint256[] memory chainIds) internal pure returns (uint256) {
+        uint256 total;
+        for (uint256 i = 0; i < chainIds.length; ++i) {
+            total += PaymentInfo.findMaxCost(payment, chainIds[i]);
+        }
+        return total;
     }
 
     function hasMaxCostForChain(Payment memory payment, uint256 chainId) internal pure returns (bool) {

--- a/src/builder/QuarkBuilderBase.sol
+++ b/src/builder/QuarkBuilderBase.sol
@@ -119,7 +119,7 @@ contract QuarkBuilderBase {
 
         for (uint256 i = 0; i < actionIntent.assetSymbolOuts.length; ++i) {
             string memory assetSymbolOut = actionIntent.assetSymbolOuts[i];
-            // Asser that there are enough of the intent token to complete the action
+            // Assert that there are enough of the intent token to complete the action
             assertFundsAvailable(actionIntent.chainId, assetSymbolOut, actionIntent.amountOuts[i], chainAccountsList);
             // Check if the assetSymbolOut is the same as the payment token
             if (Strings.stringEqIgnoreCase(assetSymbolOut, payment.currency)) {

--- a/src/builder/QuarkBuilderBase.sol
+++ b/src/builder/QuarkBuilderBase.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity ^0.8.27;
 
+import {console} from "src/builder/console.sol";
+
 import {IQuarkWallet} from "quark-core/src/interfaces/IQuarkWallet.sol";
 
 import {Actions} from "src/builder/actions/Actions.sol";
@@ -18,8 +20,9 @@ import {TokenWrapper} from "src/builder/TokenWrapper.sol";
 import {QuarkOperationHelper} from "src/builder/QuarkOperationHelper.sol";
 import {List} from "src/builder/List.sol";
 import {HashMap} from "src/builder/HashMap.sol";
+import {QuotePay} from "src/QuotePay.sol";
 
-string constant QUARK_BUILDER_VERSION = "0.3.2";
+string constant QUARK_BUILDER_VERSION = "0.4.0";
 
 contract QuarkBuilderBase {
     /* ===== Output Types ===== */
@@ -40,18 +43,19 @@ contract QuarkBuilderBase {
 
     /* ===== Constants ===== */
 
-    string constant VERSION = QUARK_BUILDER_VERSION;
+    string public constant VERSION = QUARK_BUILDER_VERSION;
 
     /* ===== Custom Errors ===== */
 
     error AssetPositionNotFound();
     error FundsUnavailable(string assetSymbol, uint256 requiredAmount, uint256 actualAmount);
-    error InvalidActionChain();
     error InvalidActionType();
     error InvalidInput();
     error MaxCostTooHigh();
     error MissingWrapperCounterpart();
+    error BalanceNotRight(uint256 paymentAssetBalance, uint256 assetsIn, uint256 assetsOut);
     error InvalidRepayActionContext();
+    error UnableToConstructQuotePay(string assetSymbol);
 
     /**
      * @dev Intent for an action to be executed by the Quark Wallet
@@ -113,24 +117,17 @@ contract QuarkBuilderBase {
 
         for (uint256 i = 0; i < actionIntent.assetSymbolOuts.length; ++i) {
             string memory assetSymbolOut = actionIntent.assetSymbolOuts[i];
-            assertFundsAvailable(
-                actionIntent.chainId, assetSymbolOut, actionIntent.amountOuts[i], chainAccountsList, payment
-            );
+            // Asser that there are enough of the intent token to complete the action
+            assertFundsAvailable(actionIntent.chainId, assetSymbolOut, actionIntent.amountOuts[i], chainAccountsList);
             // Check if the assetSymbolOut is the same as the payment token
             if (Strings.stringEqIgnoreCase(assetSymbolOut, payment.currency)) {
                 paymentTokenIsPartOfAssetSymbolOuts = true;
             }
 
-            if (
-                needsBridgedFunds(
-                    assetSymbolOut, actionIntent.amountOuts[i], actionIntent.chainId, chainAccountsList, payment
-                )
-            ) {
+            if (needsBridgedFunds(assetSymbolOut, actionIntent.amountOuts[i], actionIntent.chainId, chainAccountsList))
+            {
                 if (actionIntent.bridgeEnabled) {
                     uint256 amountNeededOnDst = actionIntent.amountOuts[i];
-                    if (payment.isToken && Strings.stringEqIgnoreCase(payment.currency, assetSymbolOut)) {
-                        amountNeededOnDst += PaymentInfo.findMaxCost(payment, actionIntent.chainId);
-                    }
                     (IQuarkWallet.QuarkOperation[] memory bridgeQuarkOperations, Actions.Action[] memory bridgeActions)
                     = Actions.constructBridgeOperations(
                         Actions.BridgeOperationInfo({
@@ -147,84 +144,22 @@ contract QuarkBuilderBase {
                     );
 
                     // Track how much is actually bridged for each asset
-                    if (HashMap.contains(assetsBridged, abi.encode(assetSymbolOut))) {
-                        uint256 existingAmountBridged = HashMap.getUint256(assetsBridged, abi.encode(assetSymbolOut));
-                        HashMap.putUint256(
-                            assetsBridged, abi.encode(assetSymbolOut), existingAmountBridged + amountNeededOnDst
-                        );
-                    } else {
-                        HashMap.putUint256(assetsBridged, abi.encode(assetSymbolOut), amountNeededOnDst);
-                    }
+                    HashMap.addOrPutUint256(assetsBridged, abi.encode(assetSymbolOut), amountNeededOnDst);
 
                     for (uint256 j = 0; j < bridgeQuarkOperations.length; ++j) {
+                        console.log("finished constructing bridge");
                         List.addQuarkOperation(quarkOperations, bridgeQuarkOperations[j]);
                         List.addAction(actions, bridgeActions[j]);
                     }
                 } else {
                     uint256 balanceOnChain =
-                        getBalanceOnChain(assetSymbolOut, actionIntent.chainId, chainAccountsList, payment);
-                    uint256 amountNeededOnChain = getAmountNeededOnChain(
-                        assetSymbolOut, actionIntent.amountOuts[i], actionIntent.chainId, payment
-                    );
+                        getBalanceOnChainIncludingCounterpart(assetSymbolOut, actionIntent.chainId, chainAccountsList);
+                    uint256 amountNeededOnChain = actionIntent.amountOuts[i];
                     uint256 maxCostOnChain =
                         payment.isToken ? PaymentInfo.findMaxCost(payment, actionIntent.chainId) : 0;
                     uint256 availableAssetBalance =
                         balanceOnChain >= maxCostOnChain ? balanceOnChain - maxCostOnChain : 0;
                     revert FundsUnavailable(assetSymbolOut, amountNeededOnChain, availableAssetBalance);
-                }
-            }
-        }
-
-        // When paying with tokens and the payment token is not an asset out, we need to bridge over the payment token
-        if (payment.isToken && !paymentTokenIsPartOfAssetSymbolOuts) {
-            uint256 maxCostOnDstChain = PaymentInfo.findMaxCost(payment, actionIntent.chainId);
-
-            // We can reduce the amount to bridge by the amount of payment tokens that are coming in to the actor's account
-            for (uint256 k = 0; k < actionIntent.assetSymbolIns.length; ++k) {
-                if (Strings.stringEqIgnoreCase(actionIntent.assetSymbolIns[k], payment.currency)) {
-                    maxCostOnDstChain = Math.subtractFlooredAtZero(maxCostOnDstChain, actionIntent.amountIns[k]);
-                }
-            }
-
-            if (
-                needsBridgedFunds(payment.currency, maxCostOnDstChain, actionIntent.chainId, chainAccountsList, payment)
-            ) {
-                if (actionIntent.bridgeEnabled) {
-                    (IQuarkWallet.QuarkOperation[] memory bridgeQuarkOperations, Actions.Action[] memory bridgeActions)
-                    = Actions.constructBridgeOperations(
-                        Actions.BridgeOperationInfo({
-                            assetSymbol: payment.currency,
-                            amountNeededOnDst: maxCostOnDstChain,
-                            dstChainId: actionIntent.chainId,
-                            recipient: actionIntent.actor,
-                            blockTimestamp: actionIntent.blockTimestamp,
-                            useQuotecall: actionIntent.useQuotecall,
-                            preferAcross: actionIntent.preferAcross
-                        }),
-                        chainAccountsList,
-                        payment
-                    );
-
-                    // Track how much is actually bridged for the payment asset
-                    if (HashMap.contains(assetsBridged, abi.encode(payment.currency))) {
-                        uint256 existingAmountBridged = HashMap.getUint256(assetsBridged, abi.encode(payment.currency));
-                        HashMap.putUint256(
-                            assetsBridged, abi.encode(payment.currency), existingAmountBridged + maxCostOnDstChain
-                        );
-                    } else {
-                        HashMap.putUint256(assetsBridged, abi.encode(payment.currency), maxCostOnDstChain);
-                    }
-
-                    for (uint256 i = 0; i < bridgeQuarkOperations.length; ++i) {
-                        List.addQuarkOperation(quarkOperations, bridgeQuarkOperations[i]);
-                        List.addAction(actions, bridgeActions[i]);
-                    }
-                } else {
-                    revert FundsUnavailable(
-                        payment.currency,
-                        maxCostOnDstChain,
-                        getBalanceOnChain(payment.currency, actionIntent.chainId, chainAccountsList, payment)
-                    );
                 }
             }
         }
@@ -258,46 +193,52 @@ contract QuarkBuilderBase {
             }
         }
 
+        console.log("finished constructing wraps");
+
         // Insert action and operation that will be wrapped with this
         List.addAction(actions, action);
         List.addQuarkOperation(quarkOperations, actionQuarkOperation);
 
-        // Convert to array
-        quarkOperationsArray = List.toQuarkOperationArray(quarkOperations);
-        actionsArray = List.toActionArray(actions);
+        console.log("added intent action to actions");
 
-        // Validate generated actions for affordability
-        // Note: Do we still need this? Seems unreachable if we always attempt to bridge enough payment token
-        // If not enough, it will always fail at the bridge step
+        // Generate a QuotePay operation if the payment method is with tokens
         if (payment.isToken) {
             uint256 supplementalPaymentTokenBalance = 0;
+            // TODO: what is this supplemental balance? is it still needed. STILL NEEDED TO ACCOUNT FOR PAYMENT TAKEN IN
             for (uint256 i = 0; i < actionIntent.assetSymbolIns.length; ++i) {
                 if (Strings.stringEqIgnoreCase(actionIntent.assetSymbolIns[i], payment.currency)) {
                     supplementalPaymentTokenBalance += actionIntent.amountIns[i];
                 }
             }
 
-            assertSufficientPaymentTokenBalances(
+            console.log("start generating quote pay");
+
+            (IQuarkWallet.QuarkOperation memory quotePayOperation, Actions.Action memory quotePayAction) =
+            generateQuotePayOperation(
                 PaymentBalanceAssertionArgs({
-                    actions: actionsArray,
+                    actions: List.toActionArray(actions),
                     chainAccountsList: chainAccountsList,
                     targetChainId: actionIntent.chainId,
                     account: actionIntent.actor,
-                    supplementalPaymentTokenBalance: supplementalPaymentTokenBalance
+                    supplementalPaymentTokenBalance: supplementalPaymentTokenBalance,
+                    payment: payment,
+                    actionIntent: actionIntent
                 })
             );
+
+            List.addAction(actions, quotePayAction);
+            List.addQuarkOperation(quarkOperations, quotePayOperation);
+
+            console.log("added quotepay to actions");
         }
+
+        // Convert to array
+        quarkOperationsArray = List.toQuarkOperationArray(quarkOperations);
+        actionsArray = List.toActionArray(actions);
 
         // Merge operations that are from the same chain into one Multicall operation
         (quarkOperationsArray, actionsArray) =
             QuarkOperationHelper.mergeSameChainOperations(quarkOperationsArray, actionsArray);
-
-        // Wrap operations around Paycall/Quotecall if payment is with token
-        if (payment.isToken) {
-            quarkOperationsArray = QuarkOperationHelper.wrapOperationsWithTokenPayment(
-                quarkOperationsArray, actionsArray, payment, actionIntent.useQuotecall
-            );
-        }
     }
 
     /* ===== Helper functions ===== */
@@ -326,23 +267,38 @@ contract QuarkBuilderBase {
         return totalBorrowForAccount + buffer;
     }
 
+    function cometWithdrawMaxAmount(
+        Accounts.ChainAccounts[] memory chainAccountsList,
+        uint256 chainId,
+        address comet,
+        address withdrawer
+    ) internal pure returns (uint256) {
+        uint256 actualWithdrawAmount = 0;
+        Accounts.CometPositions memory cometPositions = Accounts.findCometPositions(chainId, comet, chainAccountsList);
+
+        for (uint256 i = 0; i < cometPositions.basePosition.accounts.length; ++i) {
+            if (cometPositions.basePosition.accounts[i] == withdrawer) {
+                actualWithdrawAmount += cometPositions.basePosition.supplied[i];
+            }
+        }
+        return actualWithdrawAmount;
+    }
+
     function assertFundsAvailable(
         uint256 chainId,
         string memory assetSymbol,
         uint256 amount,
-        Accounts.ChainAccounts[] memory chainAccountsList,
-        PaymentInfo.Payment memory payment
+        Accounts.ChainAccounts[] memory chainAccountsList
     ) internal pure {
         // If no funds need to be bridged, then this check is satisfied
         // TODO: We might still need to check the availability of funds on the target chain, e.g. see if
         // funds are locked in a lending protocol and can't be withdrawn
-        if (!needsBridgedFunds(assetSymbol, amount, chainId, chainAccountsList, payment)) {
+        if (!needsBridgedFunds(assetSymbol, amount, chainId, chainAccountsList)) {
             return;
         }
 
         // Check each chain to see if there are enough action assets to be bridged over
         uint256 aggregateAssetBalance;
-        uint256 aggregateMaxCosts;
         for (uint256 i = 0; i < chainAccountsList.length; ++i) {
             Accounts.AssetPositions memory positions =
                 Accounts.findAssetPositions(assetSymbol, chainAccountsList[i].assetPositionsList);
@@ -351,11 +307,6 @@ contract QuarkBuilderBase {
                     || BridgeRoutes.canBridge(chainAccountsList[i].chainId, chainId, assetSymbol)
             ) {
                 aggregateAssetBalance += Accounts.sumBalances(positions);
-                // If the user opts for paying with the payment token and the payment token is the transfer token, reduce
-                // the available balance by the max cost because the max cost is reserved for paying the txn
-                if (payment.isToken && Strings.stringEqIgnoreCase(payment.currency, assetSymbol)) {
-                    aggregateMaxCosts += PaymentInfo.findMaxCost(payment, chainAccountsList[i].chainId);
-                }
             }
 
             // If the asset has wrapper counterpart and can locally wrap/unwrap, accumulate the balance of the the counterpart
@@ -365,26 +316,14 @@ contract QuarkBuilderBase {
                     && TokenWrapper.hasWrapperContract(chainAccountsList[i].chainId, assetSymbol)
             ) {
                 {
-                    uint256 counterpartBalance =
+                    aggregateAssetBalance +=
                         getWrapperCounterpartBalance(assetSymbol, chainAccountsList[i].chainId, chainAccountsList);
-                    string memory counterpartSymbol =
-                        TokenWrapper.getWrapperCounterpartSymbol(chainAccountsList[i].chainId, assetSymbol);
-                    // If the user opts for paying with payment token and the payment token is also the action token's counterpart
-                    // reduce the available balance by the max cost
-                    if (payment.isToken && Strings.stringEqIgnoreCase(payment.currency, counterpartSymbol)) {
-                        counterpartBalance = Math.subtractFlooredAtZero(
-                            counterpartBalance, PaymentInfo.findMaxCost(payment, chainAccountsList[i].chainId)
-                        );
-                    }
-                    aggregateAssetBalance += counterpartBalance;
                 }
             }
         }
 
-        uint256 aggregateAvailableAssetBalance =
-            aggregateAssetBalance >= aggregateMaxCosts ? aggregateAssetBalance - aggregateMaxCosts : 0;
-        if (aggregateAvailableAssetBalance < amount) {
-            revert FundsUnavailable(assetSymbol, amount, aggregateAvailableAssetBalance);
+        if (aggregateAssetBalance < amount) {
+            revert FundsUnavailable(assetSymbol, amount, aggregateAssetBalance);
         }
     }
 
@@ -392,13 +331,12 @@ contract QuarkBuilderBase {
         string memory assetSymbol,
         uint256 amount,
         uint256 chainId,
-        Accounts.ChainAccounts[] memory chainAccountsList,
-        PaymentInfo.Payment memory payment
+        Accounts.ChainAccounts[] memory chainAccountsList
     ) internal pure returns (bool) {
-        uint256 balanceOnChain = getBalanceOnChain(assetSymbol, chainId, chainAccountsList, payment);
-        uint256 amountNeededOnChain = getAmountNeededOnChain(assetSymbol, amount, chainId, payment);
+        // We don't need to subtract quote from balanceOnChain because quote can be paid from another chain
+        uint256 balanceOnChain = getBalanceOnChainIncludingCounterpart(assetSymbol, chainId, chainAccountsList);
 
-        return balanceOnChain < amountNeededOnChain;
+        return balanceOnChain < amount;
     }
 
     /**
@@ -436,7 +374,9 @@ contract QuarkBuilderBase {
                     chainAccountsList: chainAccountsList,
                     assetSymbol: counterpartSymbol,
                     // Note: The wrapper logic should only "wrap all" or "wrap up to" the amount needed
-                    amount: amountNeeded,
+                    // TODO: should just be amount needed, but we need to know later on how much was likel entering/leaving system
+                    amountNeeded: amountNeeded,
+                    balanceOnChain: assetBalanceOnChain,
                     chainId: chainId,
                     sender: account,
                     blockTimestamp: blockTimestamp
@@ -444,6 +384,7 @@ contract QuarkBuilderBase {
                 payment,
                 useQuotecall
             );
+            console.log("wrapping up to ", amountNeeded, assetBalanceOnChain);
             List.addQuarkOperation(quarkOperations, wrapOrUnwrapOperation);
             List.addAction(actions, wrapOrUnwrapAction);
         }
@@ -455,177 +396,332 @@ contract QuarkBuilderBase {
         uint256 targetChainId;
         address account;
         uint256 supplementalPaymentTokenBalance;
+        PaymentInfo.Payment payment;
+        ActionIntent actionIntent;
     }
 
     /**
-     * @dev Asserts that each chain with a bridge action has enough payment
-     * token to cover the payment token cost of the bridging action and that
-     * the destination chain (once bridging is complete) will have a sufficient
-     * amount of the payment token to cover the non-bridged actions.
-     *
-     * Optional `supplementalPaymentTokenBalance` param describes an amount of
-     * the payment token that might have been received in the course of an
-     * action (for example, withdrawing an asset from Compound), which would
-     * therefore not be present in `chainAccountsList` but could be used to
-     * cover action costs.
+     * @dev Generate a QuotePay operation on a single chain to cover the quoted costs for all the operations, if possible.
+     *      Reverts with FundsUnavailable if no single chain has enough to cover the total quote cost
      */
-    function assertSufficientPaymentTokenBalances(
-        Actions.Action[] memory actions,
-        Accounts.ChainAccounts[] memory chainAccountsList,
-        uint256 targetChainId,
-        address account
-    ) internal pure {
-        return assertSufficientPaymentTokenBalances(
-            PaymentBalanceAssertionArgs({
-                actions: actions,
-                chainAccountsList: chainAccountsList,
-                targetChainId: targetChainId,
-                account: account,
-                supplementalPaymentTokenBalance: 0
-            })
-        );
-    }
+    function generateQuotePayOperation(PaymentBalanceAssertionArgs memory args)
+        internal
+        pure
+        returns (IQuarkWallet.QuarkOperation memory, Actions.Action memory)
+    {
+        // Checks the chain ids that have actions
+        List.DynamicArray memory chainIdsInvolved = List.newList();
 
-    function assertSufficientPaymentTokenBalances(PaymentBalanceAssertionArgs memory args) internal pure {
-        Actions.Action[] memory bridgeActions = Actions.findActionsOfType(args.actions, Actions.ACTION_TYPE_BRIDGE);
-        Actions.Action[] memory nonBridgeActions =
-            Actions.findActionsNotOfType(args.actions, Actions.ACTION_TYPE_BRIDGE);
+        // Tracks the payment assets that are leaving and entering each chain
+        HashMap.Map memory assetsInPerChain = HashMap.newMap();
+        HashMap.Map memory assetsOutPerChain = HashMap.newMap();
 
-        string memory paymentTokenSymbol = nonBridgeActions[0].paymentTokenSymbol; // assumes all actions use the same payment token
-        uint256 paymentTokenBridgeAmount = 0;
-        // Verify bridge actions are affordable, and update plannedBridgeAmount for verifying transfer actions
-        for (uint256 i = 0; i < bridgeActions.length; ++i) {
-            Actions.BridgeActionContext memory bridgeActionContext =
-                abi.decode(bridgeActions[i].actionContext, (Actions.BridgeActionContext));
-            uint256 paymentAssetBalanceOnChain = Accounts.sumBalances(
-                Accounts.findAssetPositions(
-                    bridgeActions[i].paymentToken, bridgeActions[i].chainId, args.chainAccountsList
-                )
-            );
-            if (bridgeActionContext.token == bridgeActions[i].paymentToken) {
-                // If the payment token is the transfer token and this is the target chain, we need to account for the transfer amount
-                // If its bridge step, check if user has enough balance to cover the bridge amount
-                if (paymentAssetBalanceOnChain < bridgeActions[i].paymentMaxCost + bridgeActionContext.inputAmount) {
-                    revert MaxCostTooHigh();
-                }
-            } else {
-                // Just check payment token can cover the max cost
-                if (paymentAssetBalanceOnChain < bridgeActions[i].paymentMaxCost) {
-                    revert MaxCostTooHigh();
-                }
+        string memory paymentTokenSymbol = args.actions[0].paymentTokenSymbol; // assumes all actions use the same payment token
+        for (uint256 i = 0; i < args.actions.length; ++i) {
+            Actions.Action memory action = args.actions[i];
+
+            // Keep track of which chains have actions on them. This will be used to generate the final
+            // quote amount later.
+            if (!List.contains(chainIdsInvolved, action.chainId)) {
+                List.addUint256(chainIdsInvolved, action.chainId);
             }
 
-            if (Strings.stringEqIgnoreCase(bridgeActionContext.assetSymbol, paymentTokenSymbol)) {
-                paymentTokenBridgeAmount += bridgeActionContext.outputAmount;
-            }
-        }
-
-        uint256 targetChainPaymentTokenBalance = Accounts.sumBalances(
-            Accounts.findAssetPositions(paymentTokenSymbol, args.targetChainId, args.chainAccountsList)
-        ); // assumes that all non-bridge actions occur on the target chain
-        uint256 paymentTokenCost = 0;
-
-        for (uint256 i = 0; i < nonBridgeActions.length; ++i) {
-            Actions.Action memory nonBridgeAction = nonBridgeActions[i];
-            if (nonBridgeAction.chainId != args.targetChainId) {
-                revert InvalidActionChain();
-            }
-            paymentTokenCost += nonBridgeAction.paymentMaxCost;
-
-            if (Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_BORROW)) {
-                continue;
-            } else if (Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_MORPHO_BORROW)) {
-                continue;
-            } else if (Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_MORPHO_CLAIM_REWARDS))
-            {
-                continue;
-            } else if (Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_MORPHO_REPAY)) {
-                Actions.MorphoRepayActionContext memory morphoRepayActionContext =
-                    abi.decode(nonBridgeAction.actionContext, (Actions.MorphoRepayActionContext));
-                if (morphoRepayActionContext.amount == type(uint256).max) {
-                    paymentTokenCost += morphoRepayMaxAmount(
-                        args.chainAccountsList,
-                        morphoRepayActionContext.chainId,
-                        morphoRepayActionContext.token,
-                        morphoRepayActionContext.collateralToken,
-                        args.account
+            // Depending on the action type, update the `assetsInPerChain` and/or `assetsOutPerChain` maps
+            if (Strings.stringEqIgnoreCase(action.actionType, Actions.ACTION_TYPE_BRIDGE)) {
+                Actions.BridgeActionContext memory bridgeActionContext =
+                    abi.decode(action.actionContext, (Actions.BridgeActionContext));
+                if (Strings.stringEqIgnoreCase(bridgeActionContext.assetSymbol, paymentTokenSymbol)) {
+                    HashMap.addOrPutUint256(
+                        assetsInPerChain,
+                        abi.encode(bridgeActionContext.destinationChainId),
+                        bridgeActionContext.outputAmount
                     );
-                } else {
-                    paymentTokenCost += morphoRepayActionContext.amount;
+                    HashMap.addOrPutUint256(
+                        assetsOutPerChain, abi.encode(bridgeActionContext.chainId), bridgeActionContext.inputAmount
+                    );
                 }
-            } else if (Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_REPAY)) {
+            } else if (Strings.stringEqIgnoreCase(action.actionType, Actions.ACTION_TYPE_BORROW)) {
+                Actions.BorrowActionContext memory borrowActionContext =
+                    abi.decode(action.actionContext, (Actions.BorrowActionContext));
+                if (Strings.stringEqIgnoreCase(borrowActionContext.assetSymbol, paymentTokenSymbol)) {
+                    HashMap.addOrPutUint256(
+                        assetsInPerChain, abi.encode(borrowActionContext.chainId), borrowActionContext.amount
+                    );
+                }
+
+                for (uint256 j = 0; j < borrowActionContext.collateralAssetSymbols.length; ++j) {
+                    if (Strings.stringEqIgnoreCase(borrowActionContext.collateralAssetSymbols[j], paymentTokenSymbol)) {
+                        HashMap.addOrPutUint256(
+                            assetsOutPerChain,
+                            abi.encode(borrowActionContext.chainId),
+                            borrowActionContext.collateralAmounts[j]
+                        );
+                    }
+                }
+            } else if (Strings.stringEqIgnoreCase(action.actionType, Actions.ACTION_TYPE_MORPHO_BORROW)) {
+                Actions.MorphoBorrowActionContext memory borrowActionContext =
+                    abi.decode(action.actionContext, (Actions.MorphoBorrowActionContext));
+                if (Strings.stringEqIgnoreCase(borrowActionContext.assetSymbol, paymentTokenSymbol)) {
+                    HashMap.addOrPutUint256(
+                        assetsInPerChain, abi.encode(borrowActionContext.chainId), borrowActionContext.amount
+                    );
+                }
+                if (Strings.stringEqIgnoreCase(borrowActionContext.collateralAssetSymbol, paymentTokenSymbol)) {
+                    HashMap.addOrPutUint256(
+                        assetsOutPerChain, abi.encode(borrowActionContext.chainId), borrowActionContext.collateralAmount
+                    );
+                }
+            } else if (Strings.stringEqIgnoreCase(action.actionType, Actions.ACTION_TYPE_MORPHO_CLAIM_REWARDS)) {
+                // TODO: Treat rewards claimed as asset in?
+                continue;
+            } else if (Strings.stringEqIgnoreCase(action.actionType, Actions.ACTION_TYPE_MORPHO_REPAY)) {
+                Actions.MorphoRepayActionContext memory morphoRepayActionContext =
+                    abi.decode(action.actionContext, (Actions.MorphoRepayActionContext));
+                if (Strings.stringEqIgnoreCase(morphoRepayActionContext.assetSymbol, paymentTokenSymbol)) {
+                    uint256 repayAmount;
+                    if (morphoRepayActionContext.amount == type(uint256).max) {
+                        repayAmount = morphoRepayMaxAmount(
+                            args.chainAccountsList,
+                            morphoRepayActionContext.chainId,
+                            morphoRepayActionContext.token,
+                            morphoRepayActionContext.collateralToken,
+                            args.account
+                        );
+                    } else {
+                        repayAmount = morphoRepayActionContext.amount;
+                    }
+                    HashMap.addOrPutUint256(
+                        assetsOutPerChain, abi.encode(morphoRepayActionContext.chainId), repayAmount
+                    );
+                }
+                if (Strings.stringEqIgnoreCase(morphoRepayActionContext.collateralAssetSymbol, paymentTokenSymbol)) {
+                    HashMap.addOrPutUint256(
+                        assetsInPerChain,
+                        abi.encode(morphoRepayActionContext.chainId),
+                        morphoRepayActionContext.collateralAmount
+                    );
+                }
+            } else if (Strings.stringEqIgnoreCase(action.actionType, Actions.ACTION_TYPE_REPAY)) {
                 Actions.RepayActionContext memory cometRepayActionContext =
-                    abi.decode(nonBridgeAction.actionContext, (Actions.RepayActionContext));
+                    abi.decode(action.actionContext, (Actions.RepayActionContext));
                 if (Strings.stringEqIgnoreCase(cometRepayActionContext.assetSymbol, paymentTokenSymbol)) {
+                    uint256 repayAmount;
                     if (cometRepayActionContext.amount == type(uint256).max) {
-                        paymentTokenCost += cometRepayMaxAmount(
+                        repayAmount = cometRepayMaxAmount(
                             args.chainAccountsList,
                             cometRepayActionContext.chainId,
                             cometRepayActionContext.comet,
                             args.account
                         );
                     } else {
-                        paymentTokenCost += cometRepayActionContext.amount;
+                        repayAmount = cometRepayActionContext.amount;
+                    }
+                    HashMap.addOrPutUint256(assetsOutPerChain, abi.encode(cometRepayActionContext.chainId), repayAmount);
+                }
+
+                for (uint256 j = 0; j < cometRepayActionContext.collateralAssetSymbols.length; ++j) {
+                    if (
+                        Strings.stringEqIgnoreCase(
+                            cometRepayActionContext.collateralAssetSymbols[j], paymentTokenSymbol
+                        )
+                    ) {
+                        HashMap.addOrPutUint256(
+                            assetsInPerChain,
+                            abi.encode(cometRepayActionContext.chainId),
+                            cometRepayActionContext.collateralAmounts[j]
+                        );
                     }
                 }
-            } else if (Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_SUPPLY)) {
+            } else if (Strings.stringEqIgnoreCase(action.actionType, Actions.ACTION_TYPE_SUPPLY)) {
                 Actions.SupplyActionContext memory cometSupplyActionContext =
-                    abi.decode(nonBridgeAction.actionContext, (Actions.SupplyActionContext));
+                    abi.decode(action.actionContext, (Actions.SupplyActionContext));
                 if (Strings.stringEqIgnoreCase(cometSupplyActionContext.assetSymbol, paymentTokenSymbol)) {
-                    paymentTokenCost += cometSupplyActionContext.amount;
+                    HashMap.addOrPutUint256(
+                        assetsOutPerChain, abi.encode(cometSupplyActionContext.chainId), cometSupplyActionContext.amount
+                    );
                 }
-            } else if (Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_MORPHO_VAULT_SUPPLY))
-            {
+            } else if (Strings.stringEqIgnoreCase(action.actionType, Actions.ACTION_TYPE_MORPHO_VAULT_SUPPLY)) {
                 Actions.MorphoVaultSupplyActionContext memory morphoVaultSupplyActionContext =
-                    abi.decode(nonBridgeAction.actionContext, (Actions.MorphoVaultSupplyActionContext));
+                    abi.decode(action.actionContext, (Actions.MorphoVaultSupplyActionContext));
                 if (Strings.stringEqIgnoreCase(morphoVaultSupplyActionContext.assetSymbol, paymentTokenSymbol)) {
-                    paymentTokenCost += morphoVaultSupplyActionContext.amount;
+                    HashMap.addOrPutUint256(
+                        assetsOutPerChain,
+                        abi.encode(morphoVaultSupplyActionContext.chainId),
+                        morphoVaultSupplyActionContext.amount
+                    );
                 }
-            } else if (Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_SWAP)) {
+            } else if (Strings.stringEqIgnoreCase(action.actionType, Actions.ACTION_TYPE_SWAP)) {
                 Actions.SwapActionContext memory swapActionContext =
-                    abi.decode(nonBridgeAction.actionContext, (Actions.SwapActionContext));
+                    abi.decode(action.actionContext, (Actions.SwapActionContext));
                 if (Strings.stringEqIgnoreCase(swapActionContext.inputAssetSymbol, paymentTokenSymbol)) {
-                    paymentTokenCost += swapActionContext.inputAmount;
+                    HashMap.addOrPutUint256(
+                        assetsOutPerChain, abi.encode(swapActionContext.chainId), swapActionContext.inputAmount
+                    );
                 }
-            } else if (Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_RECURRING_SWAP)) {
+                if (Strings.stringEqIgnoreCase(swapActionContext.outputAssetSymbol, paymentTokenSymbol)) {
+                    HashMap.addOrPutUint256(
+                        assetsInPerChain, abi.encode(swapActionContext.chainId), swapActionContext.outputAmount
+                    );
+                }
+            } else if (Strings.stringEqIgnoreCase(action.actionType, Actions.ACTION_TYPE_RECURRING_SWAP)) {
                 Actions.RecurringSwapActionContext memory recurringSwapActionContext =
-                    abi.decode(nonBridgeAction.actionContext, (Actions.RecurringSwapActionContext));
+                    abi.decode(action.actionContext, (Actions.RecurringSwapActionContext));
                 if (Strings.stringEqIgnoreCase(recurringSwapActionContext.inputAssetSymbol, paymentTokenSymbol)) {
-                    paymentTokenCost += recurringSwapActionContext.inputAmount;
+                    HashMap.addOrPutUint256(
+                        assetsOutPerChain,
+                        abi.encode(recurringSwapActionContext.chainId),
+                        recurringSwapActionContext.inputAmount
+                    );
                 }
-            } else if (Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_TRANSFER)) {
+                if (Strings.stringEqIgnoreCase(recurringSwapActionContext.outputAssetSymbol, paymentTokenSymbol)) {
+                    HashMap.addOrPutUint256(
+                        assetsInPerChain,
+                        abi.encode(recurringSwapActionContext.chainId),
+                        recurringSwapActionContext.outputAmount
+                    );
+                }
+            } else if (Strings.stringEqIgnoreCase(action.actionType, Actions.ACTION_TYPE_TRANSFER)) {
                 Actions.TransferActionContext memory transferActionContext =
-                    abi.decode(nonBridgeAction.actionContext, (Actions.TransferActionContext));
+                    abi.decode(action.actionContext, (Actions.TransferActionContext));
                 if (Strings.stringEqIgnoreCase(transferActionContext.assetSymbol, paymentTokenSymbol)) {
-                    paymentTokenCost += transferActionContext.amount;
+                    HashMap.addOrPutUint256(
+                        assetsOutPerChain, abi.encode(transferActionContext.chainId), transferActionContext.amount
+                    );
                 }
             } else if (
-                Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_UNWRAP)
-                    || Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_WRAP)
+                Strings.stringEqIgnoreCase(action.actionType, Actions.ACTION_TYPE_UNWRAP)
+                    || Strings.stringEqIgnoreCase(action.actionType, Actions.ACTION_TYPE_WRAP)
             ) {
-                // XXX test that wrapping/unwrapping impacts paymentTokenCost
                 Actions.WrapOrUnwrapActionContext memory wrapOrUnwrapActionContext =
-                    abi.decode(nonBridgeAction.actionContext, (Actions.WrapOrUnwrapActionContext));
-                if (Strings.stringEqIgnoreCase(wrapOrUnwrapActionContext.fromAssetSymbol, paymentTokenSymbol)) {
-                    paymentTokenCost += wrapOrUnwrapActionContext.amount;
+                    abi.decode(action.actionContext, (Actions.WrapOrUnwrapActionContext));
+                if (Strings.stringEqIgnoreCase(wrapOrUnwrapActionContext.toAssetSymbol, paymentTokenSymbol)) {
+                    console.log("wrap  ", wrapOrUnwrapActionContext.toAssetSymbol, wrapOrUnwrapActionContext.amount);
+                    HashMap.addOrPutUint256(
+                        assetsInPerChain,
+                        abi.encode(wrapOrUnwrapActionContext.chainId),
+                        wrapOrUnwrapActionContext.amount
+                    );
                 }
-            } else if (Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_WITHDRAW)) {
-                continue;
-            } else if (
-                Strings.stringEqIgnoreCase(nonBridgeAction.actionType, Actions.ACTION_TYPE_MORPHO_VAULT_WITHDRAW)
-            ) {
-                continue;
+                if (Strings.stringEqIgnoreCase(wrapOrUnwrapActionContext.fromAssetSymbol, paymentTokenSymbol)) {
+                    console.log("unwrap  ", wrapOrUnwrapActionContext.fromAssetSymbol, wrapOrUnwrapActionContext.amount);
+                    HashMap.addOrPutUint256(
+                        assetsOutPerChain,
+                        abi.encode(wrapOrUnwrapActionContext.chainId),
+                        wrapOrUnwrapActionContext.amount
+                    );
+                }
+            } else if (Strings.stringEqIgnoreCase(action.actionType, Actions.ACTION_TYPE_WITHDRAW)) {
+                Actions.WithdrawActionContext memory withdrawActionContext =
+                    abi.decode(action.actionContext, (Actions.WithdrawActionContext));
+                if (Strings.stringEqIgnoreCase(withdrawActionContext.assetSymbol, paymentTokenSymbol)) {
+                    // If withdrawing max, we need to calculate the approximate amount that will be withdrawn
+                    uint256 withdrawAmount = withdrawActionContext.amount == type(uint256).max
+                        ? cometWithdrawMaxAmount(
+                            args.chainAccountsList,
+                            withdrawActionContext.chainId,
+                            withdrawActionContext.comet,
+                            args.actionIntent.actor
+                        )
+                        : withdrawActionContext.amount;
+                    console.log("Withdraw amount is ", withdrawAmount, withdrawActionContext.amount);
+                    HashMap.addOrPutUint256(assetsInPerChain, abi.encode(withdrawActionContext.chainId), withdrawAmount);
+                }
+            } else if (Strings.stringEqIgnoreCase(action.actionType, Actions.ACTION_TYPE_MORPHO_VAULT_WITHDRAW)) {
+                Actions.MorphoVaultWithdraw memory withdrawActionContext =
+                    abi.decode(action.actionContext, (Actions.MorphoVaultWithdraw));
+                if (Strings.stringEqIgnoreCase(withdrawActionContext.assetSymbol, paymentTokenSymbol)) {
+                    // TODO: handle max (do we need to do it for supply and transfer as well?)
+                    HashMap.addOrPutUint256(
+                        assetsInPerChain, abi.encode(withdrawActionContext.chainId), withdrawActionContext.amount
+                    );
+                }
             } else {
                 revert InvalidActionType();
             }
         }
 
-        if (
-            paymentTokenCost
-                > (targetChainPaymentTokenBalance + paymentTokenBridgeAmount + args.supplementalPaymentTokenBalance)
-        ) {
-            revert MaxCostTooHigh();
+        for (uint256 i = 0; i < args.chainAccountsList.length; ++i) {
+            uint256 chainId = args.chainAccountsList[i].chainId;
+
+            // Generate quote amount based on which chains have an operation on them
+            uint256 quoteAmount = PaymentInfo.totalCost(args.payment, List.toUint256Array(chainIdsInvolved));
+            // Add the quote for the current chain if it is not already included in the sum
+            if (!List.contains(chainIdsInvolved, chainId)) {
+                quoteAmount += PaymentInfo.findMaxCost(args.payment, chainId);
+            }
+
+            console.log("quote amount is ", quoteAmount);
+
+            // Calculate the net payment balance on this chain
+            // TODO: Need to be modified when supporting multiple accounts per chain, since this currently assumes all assets are in one account.
+            //       Will need a 2D map for assetsIn/Out to map from chainId -> account
+            Accounts.AssetPositions memory paymentAssetPositions =
+                Accounts.findAssetPositions(paymentTokenSymbol, args.chainAccountsList[i].assetPositionsList);
+            uint256 paymentAssetBalanceOnChain = Accounts.sumBalances(paymentAssetPositions);
+
+            // TODO: Right now, we hack around lack of multi account support by just taking the first account with non-zero balance or defaulting to the first account
+            address payer = paymentAssetPositions.accountBalances[0].account;
+            for (uint256 j = 0; j < paymentAssetPositions.accountBalances.length; ++j) {
+                if (paymentAssetPositions.accountBalances[j].balance > 0) {
+                    payer = paymentAssetPositions.accountBalances[j].account;
+                    break;
+                }
+            }
+
+            console.log("payer is ", payer);
+
+            if (
+                paymentAssetBalanceOnChain + HashMap.getOrDefaultUint256(assetsInPerChain, abi.encode(chainId), 0)
+                    < HashMap.getOrDefaultUint256(assetsOutPerChain, abi.encode(chainId), 0)
+            ) {
+                // Note: This should be unreachable. Something is very wrong if this hits!
+                revert BalanceNotRight(
+                    paymentAssetBalanceOnChain,
+                    HashMap.getOrDefaultUint256(assetsInPerChain, abi.encode(chainId), 0),
+                    HashMap.getOrDefaultUint256(assetsOutPerChain, abi.encode(chainId), 0)
+                );
+            }
+            console.log("post-check");
+
+            uint256 netPaymentAssetBalanceOnChain = paymentAssetBalanceOnChain
+                + HashMap.getOrDefaultUint256(assetsInPerChain, abi.encode(chainId), 0)
+                - HashMap.getOrDefaultUint256(assetsOutPerChain, abi.encode(chainId), 0);
+
+            console.log(
+                "assets in and out ",
+                HashMap.getOrDefaultUint256(assetsInPerChain, abi.encode(chainId), 0),
+                HashMap.getOrDefaultUint256(assetsOutPerChain, abi.encode(chainId), 0)
+            );
+            console.log("checking condition", netPaymentAssetBalanceOnChain, quoteAmount);
+
+            // Skip if there is not enough net payment balance on this chain
+            if (netPaymentAssetBalanceOnChain < quoteAmount) {
+                continue;
+            }
+
+            console.log("constructing quote pay");
+
+            return Actions.quotePay(
+                Actions.QuotePayInfo({
+                    chainAccountsList: args.chainAccountsList,
+                    assetSymbol: paymentTokenSymbol,
+                    amount: quoteAmount,
+                    chainId: chainId,
+                    sender: payer,
+                    blockTimestamp: args.actionIntent.blockTimestamp
+                }),
+                args.payment
+            );
         }
+
+        // NOTE: This means a QuotePay was not able to be constructed. Currently reverts even if user has a total amount more
+        //       than the quote amount if they cannot cover the whole quote amount on any single chain.
+        revert UnableToConstructQuotePay(paymentTokenSymbol);
+        // revert UnableToConstructQuotePay(
+        //     paymentTokenSymbol,
+        //     PaymentInfo.totalCost(args.payment, List.toUint256Array(chainIdsInvolved)),
+        //     Accounts.totalBalance(paymentTokenSymbol, args.chainAccountsList)
+        // );
     }
 
     function getWrapperCounterpartBalance(
@@ -643,28 +739,17 @@ contract QuarkBuilderBase {
         revert MissingWrapperCounterpart();
     }
 
-    function getBalanceOnChain(
+    function getBalanceOnChainIncludingCounterpart(
         string memory assetSymbol,
         uint256 chainId,
-        Accounts.ChainAccounts[] memory chainAccountsList,
-        PaymentInfo.Payment memory payment
+        Accounts.ChainAccounts[] memory chainAccountsList
     ) internal pure returns (uint256) {
         uint256 balanceOnChain = Accounts.getBalanceOnChain(assetSymbol, chainId, chainAccountsList);
 
         // If there exists a counterpart token, try to wrap/unwrap first before attempting to bridge
         if (TokenWrapper.hasWrapperContract(chainId, assetSymbol)) {
+            // TODO: This won't work for wrapper contracts that are not 1:1 with the underlying (e.g. wstETH vs stETH)
             uint256 counterpartBalance = getWrapperCounterpartBalance(assetSymbol, chainId, chainAccountsList);
-            // Subtract max cost if the counterpart token is the payment token
-            if (
-                payment.isToken
-                    && Strings.stringEqIgnoreCase(
-                        payment.currency, TokenWrapper.getWrapperCounterpartSymbol(chainId, assetSymbol)
-                    )
-            ) {
-                // 0 if account can't afford to wrap/unwrap == can't use that balance
-                counterpartBalance =
-                    Math.subtractFlooredAtZero(counterpartBalance, PaymentInfo.findMaxCost(payment, chainId));
-            }
             balanceOnChain += counterpartBalance;
         }
 

--- a/src/builder/QuarkOperationHelper.sol
+++ b/src/builder/QuarkOperationHelper.sol
@@ -114,7 +114,6 @@ library QuarkOperationHelper {
             primaryQuarkOperation = quarkOperations[quarkOperations.length - 1];
             primaryAction = actions[actions.length - 1];
         }
-        // IQuarkWallet.QuarkOperation memory lastQuarkOperation = quarkOperations[quarkOperations.length - 1];
         IQuarkWallet.QuarkOperation memory mergedQuarkOperation = IQuarkWallet.QuarkOperation({
             nonce: primaryQuarkOperation.nonce,
             isReplayable: primaryQuarkOperation.isReplayable,

--- a/src/builder/QuarkOperationHelper.sol
+++ b/src/builder/QuarkOperationHelper.sol
@@ -110,11 +110,9 @@ library QuarkOperationHelper {
         ) {
             primaryQuarkOperation = quarkOperations[quarkOperations.length - 2];
             primaryAction = actions[actions.length - 2];
-            console.log("Taking second to last");
         } else {
             primaryQuarkOperation = quarkOperations[quarkOperations.length - 1];
             primaryAction = actions[actions.length - 1];
-            console.log("Taking last");
         }
         // IQuarkWallet.QuarkOperation memory lastQuarkOperation = quarkOperations[quarkOperations.length - 1];
         IQuarkWallet.QuarkOperation memory mergedQuarkOperation = IQuarkWallet.QuarkOperation({

--- a/src/builder/Quotes.sol
+++ b/src/builder/Quotes.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity ^0.8.27;
+
+import {Accounts} from "src/builder/Accounts.sol";
+import {PaymentInfo} from "src/builder/PaymentInfo.sol";
+import {Strings} from "src/builder/Strings.sol";
+
+library Quotes {
+    string public constant OP_TYPE_BASELINE = "BASELINE";
+
+    error NoKnownAssetQuote(string symbol);
+
+    struct Quote {
+        bytes32 quoteId;
+        uint256 issuedAt;
+        uint256 expiresAt;
+        AssetQuote[] assetQuotes;
+        NetworkOperationFee[] networkOperationFees;
+    }
+
+    struct AssetQuote {
+        string symbol;
+        uint256 price;
+    }
+
+    struct NetworkOperationFee {
+        uint256 chainId;
+        string opType;
+        uint256 price;
+    }
+
+    function getPaymentFromQuotesAndSymbol(
+        Accounts.ChainAccounts[] memory chainAccountsList,
+        Quote memory quote,
+        string memory symbol
+    ) internal pure returns (PaymentInfo.Payment memory) {
+        if (Strings.stringEqIgnoreCase(symbol, "USD")) {
+            return PaymentInfo.Payment({
+                isToken: false,
+                currency: symbol,
+                quoteId: quote.quoteId,
+                maxCosts: new PaymentInfo.PaymentMaxCost[](0)
+            });
+        }
+
+        AssetQuote memory assetQuote;
+        bool assetQuoteFound = false;
+
+        for (uint256 i = 0; i < quote.assetQuotes.length; ++i) {
+            if (Strings.stringEqIgnoreCase(symbol, quote.assetQuotes[i].symbol)) {
+                assetQuote = quote.assetQuotes[i];
+                assetQuoteFound = true;
+            }
+        }
+
+        if (!assetQuoteFound) {
+            revert NoKnownAssetQuote(symbol);
+        }
+
+        PaymentInfo.PaymentMaxCost[] memory paymentMaxCosts =
+            new PaymentInfo.PaymentMaxCost[](quote.networkOperationFees.length);
+
+        for (uint256 i = 0; i < quote.networkOperationFees.length; ++i) {
+            NetworkOperationFee memory networkOperationFee = quote.networkOperationFees[i];
+
+            Accounts.ChainAccounts memory chainAccountListByChainId =
+                Accounts.findChainAccounts(networkOperationFee.chainId, chainAccountsList);
+
+            Accounts.AssetPositions memory singularAssetPositionsForSymbol =
+                Accounts.findAssetPositions(symbol, chainAccountListByChainId.assetPositionsList);
+
+            paymentMaxCosts[i] = PaymentInfo.PaymentMaxCost({
+                chainId: networkOperationFee.chainId,
+                amount: (networkOperationFee.price * (10 ** singularAssetPositionsForSymbol.decimals)) / assetQuote.price
+            });
+        }
+
+        return PaymentInfo.Payment({isToken: true, currency: symbol, quoteId: quote.quoteId, maxCosts: paymentMaxCosts});
+    }
+}

--- a/src/builder/actions/Actions.sol
+++ b/src/builder/actions/Actions.sol
@@ -74,6 +74,9 @@ library Actions {
     uint256 constant RECURRING_SWAP_MAX_SLIPPAGE = 1e17; // 1%
     uint256 constant RECURRING_SWAP_WINDOW_LENGTH = 1 days;
 
+    // TODO: Move to BuilderPack
+    address constant QUOTE_PAY_RECIPIENT = 0x7ea8d6119596016935543d90Ee8f5126285060A1;
+
     /* ===== Custom Errors ===== */
 
     error BridgingUnsupportedForAsset();
@@ -1469,12 +1472,7 @@ library Actions {
         Accounts.QuarkSecret memory accountSecret = Accounts.findQuarkSecret(quotePayInfo.sender, accounts.quarkSecrets);
 
         bytes memory scriptCalldata = abi.encodeWithSelector(
-            QuotePay.pay.selector,
-            // TODO: Does this work in a multi-account world?
-            quotePayInfo.sender,
-            assetPositions.asset,
-            quotePayInfo.amount,
-            payment.quoteId
+            QuotePay.pay.selector, QUOTE_PAY_RECIPIENT, assetPositions.asset, quotePayInfo.amount, payment.quoteId
         );
         // Construct QuarkOperation
         IQuarkWallet.QuarkOperation memory quarkOperation = IQuarkWallet.QuarkOperation({

--- a/src/builder/actions/Actions.sol
+++ b/src/builder/actions/Actions.sol
@@ -1755,6 +1755,10 @@ library Actions {
         return (quarkOperation, action);
     }
 
+    function isRecurringAction(Action memory action) internal pure returns (bool) {
+        return Strings.stringEqIgnoreCase(action.actionType, ACTION_TYPE_RECURRING_SWAP);
+    }
+
     function findActionsOfType(Action[] memory actions, string memory actionType)
         internal
         pure

--- a/src/builder/actions/Actions.sol
+++ b/src/builder/actions/Actions.sol
@@ -1470,7 +1470,7 @@ library Actions {
 
         bytes memory scriptCalldata = abi.encodeWithSelector(
             QuotePay.pay.selector,
-            // TODO: DOES THIS WORK IN A MULTI-ACCOUNT WORLD?
+            // TODO: Does this work in a multi-account world?
             quotePayInfo.sender,
             assetPositions.asset,
             quotePayInfo.amount,
@@ -1502,7 +1502,7 @@ library Actions {
             quarkAccount: quotePayInfo.sender,
             actionType: ACTION_TYPE_QUOTE_PAY,
             actionContext: abi.encode(quotePayActionContext),
-            // TODO: UPDATE THIS (paymentMethodForPayment)
+            // TODO: Update this (paymentMethodForPayment)
             paymentMethod: PaymentInfo.paymentMethodForPayment(payment, true),
             paymentToken: payment.isToken
                 ? PaymentInfo.knownToken(payment.currency, quotePayInfo.chainId).token
@@ -1650,7 +1650,6 @@ library Actions {
         return (quarkOperation, action);
     }
 
-    // TODO: NEED TO SOMEHOW USE PAYCALL INSTEAD OF QUOTEPAY HERE...
     function recurringSwap(RecurringSwapParams memory swap, PaymentInfo.Payment memory payment, bool useQuotecall)
         internal
         pure

--- a/src/builder/actions/CometActionsBuilder.sol
+++ b/src/builder/actions/CometActionsBuilder.sol
@@ -290,16 +290,13 @@ contract CometActionsBuilder is QuarkBuilderBase {
 
         uint256 actualWithdrawAmount = cometWithdrawIntent.amount;
         if (isMaxWithdraw) {
-            actualWithdrawAmount = 0;
-            // When doing a maxWithdraw will need to find the actual amount instead of uint256 max
-            Accounts.CometPositions memory cometPositions =
-                Accounts.findCometPositions(cometWithdrawIntent.chainId, cometWithdrawIntent.comet, chainAccountsList);
-
-            for (uint256 i = 0; i < cometPositions.basePosition.accounts.length; ++i) {
-                if (cometPositions.basePosition.accounts[i] == cometWithdrawIntent.withdrawer) {
-                    actualWithdrawAmount += cometPositions.basePosition.supplied[i];
-                }
-            }
+            // When doing a max withdraw, we need to find the actual approximate amount instead of using uint256 max
+            actualWithdrawAmount = cometWithdrawMaxAmount(
+                chainAccountsList,
+                cometWithdrawIntent.chainId,
+                cometWithdrawIntent.comet,
+                cometWithdrawIntent.withdrawer
+            );
         }
 
         (IQuarkWallet.QuarkOperation memory cometWithdrawQuarkOperation, Actions.Action memory cometWithdrawAction) =

--- a/src/builder/actions/MorphoVaultActionsBuilder.sol
+++ b/src/builder/actions/MorphoVaultActionsBuilder.sol
@@ -121,20 +121,9 @@ contract MorphoVaultActionsBuilder is QuarkBuilderBase {
 
         uint256 actualWithdrawAmount = withdrawIntent.amount;
         if (isMaxWithdraw) {
-            actualWithdrawAmount = 0;
-            // when doing a maxWithdraw of the payment token, add the account's supplied balance
-            // as supplemental payment token balance
-            Accounts.MorphoVaultPositions memory morphoVaultPositions = Accounts.findMorphoVaultPositions(
-                withdrawIntent.chainId,
-                Accounts.findAssetPositions(withdrawIntent.assetSymbol, withdrawIntent.chainId, chainAccountsList).asset,
-                chainAccountsList
+            actualWithdrawAmount = morphoWithdrawMaxAmount(
+                chainAccountsList, withdrawIntent.chainId, withdrawIntent.assetSymbol, withdrawIntent.withdrawer
             );
-
-            for (uint256 i = 0; i < morphoVaultPositions.accounts.length; ++i) {
-                if (morphoVaultPositions.accounts[i] == withdrawIntent.withdrawer) {
-                    actualWithdrawAmount += morphoVaultPositions.balances[i];
-                }
-            }
         }
 
         (IQuarkWallet.QuarkOperation memory cometWithdrawQuarkOperation, Actions.Action memory cometWithdrawAction) =

--- a/src/builder/actions/TransferActionsBuilder.sol
+++ b/src/builder/actions/TransferActionsBuilder.sol
@@ -11,6 +11,7 @@ import {MorphoInfo} from "src/builder/MorphoInfo.sol";
 import {Strings} from "src/builder/Strings.sol";
 import {PaycallWrapper} from "src/builder/PaycallWrapper.sol";
 import {QuotecallWrapper} from "src/builder/QuotecallWrapper.sol";
+import {Quotes} from "src/builder/Quotes.sol";
 import {PaymentInfo} from "src/builder/PaymentInfo.sol";
 import {TokenWrapper} from "src/builder/TokenWrapper.sol";
 import {QuarkOperationHelper} from "src/builder/QuarkOperationHelper.sol";
@@ -26,13 +27,17 @@ contract TransferActionsBuilder is QuarkBuilderBase {
         address recipient;
         uint256 blockTimestamp;
         bool preferAcross;
+        string paymentAssetSymbol;
     }
 
     function transfer(
         TransferIntent memory transferIntent,
         Accounts.ChainAccounts[] memory chainAccountsList,
-        PaymentInfo.Payment memory payment
+        Quotes.Quote memory quote
     ) external pure returns (BuilderResult memory) {
+        PaymentInfo.Payment memory payment =
+            Quotes.getPaymentFromQuotesAndSymbol(chainAccountsList, quote, transferIntent.paymentAssetSymbol);
+
         // If the action is paid for with tokens, filter out any chain accounts that do not have corresponding payment information
         if (payment.isToken) {
             chainAccountsList = Accounts.findChainAccountsWithPaymentInfo(chainAccountsList, payment);

--- a/test/QuotePay.t.sol
+++ b/test/QuotePay.t.sol
@@ -68,7 +68,7 @@ contract QuotePayTest is Test {
         QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
             wallet,
             quotePay,
-            abi.encodeWithSelector(QuotePay.run.selector, payee, USDC, 10e6, QUOTE_ID),
+            abi.encodeWithSelector(QuotePay.pay.selector, payee, USDC, 10e6, QUOTE_ID),
             ScriptType.ScriptSource
         );
         bytes memory signature = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
@@ -94,7 +94,7 @@ contract QuotePayTest is Test {
         QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
             wallet,
             quotePay,
-            abi.encodeWithSelector(QuotePay.run.selector, payee, USDT, 10e6, QUOTE_ID),
+            abi.encodeWithSelector(QuotePay.pay.selector, payee, USDT, 10e6, QUOTE_ID),
             ScriptType.ScriptSource
         );
         bytes memory signature = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
@@ -119,7 +119,7 @@ contract QuotePayTest is Test {
         QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
             wallet,
             quotePay,
-            abi.encodeWithSelector(QuotePay.run.selector, payee, WBTC, 30e3, QUOTE_ID),
+            abi.encodeWithSelector(QuotePay.pay.selector, payee, WBTC, 30e3, QUOTE_ID),
             ScriptType.ScriptSource
         );
         bytes memory signature = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
@@ -142,7 +142,7 @@ contract QuotePayTest is Test {
         QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
             wallet,
             quotePay,
-            abi.encodeWithSelector(QuotePay.run.selector, payee, USDC, 10e6, QUOTE_ID),
+            abi.encodeWithSelector(QuotePay.pay.selector, payee, USDC, 10e6, QUOTE_ID),
             ScriptType.ScriptSource
         );
         bytes memory signature = new SignatureHelper().signOp(alicePrivateKey, wallet, op);

--- a/test/builder/BridgingLogic.t.sol
+++ b/test/builder/BridgingLogic.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.27;
 
 import "forge-std/Test.sol";
-import "forge-std/console.sol";
 
 import {QuarkBuilderTest} from "test/builder/lib/QuarkBuilderTest.sol";
 

--- a/test/builder/BridgingLogic.t.sol
+++ b/test/builder/BridgingLogic.t.sol
@@ -62,13 +62,14 @@ contract BridgingLogicTest is Test, QuarkBuilderTest {
                 sender: address(0xb0b),
                 recipient: address(0xceecee),
                 blockTimestamp: BLOCK_TIMESTAMP,
-                preferAcross: false
+                preferAcross: false,
+                paymentAssetSymbol: "USD"
             }), // transfer 1e18 WETH on chain 8453 to 0xceecee
             chainAccountsList,
-            paymentUsd_()
+            quote_()
         );
 
-        assertEq(result.paymentCurrency, "usd", "usd currency");
+        assertEq(result.paymentCurrency, "USD", "usd currency");
 
         address multicallAddress = CodeJarHelper.getCodeAddress(type(Multicall).creationCode);
         address wrapperActionsAddress = CodeJarHelper.getCodeAddress(type(WrapperActions).creationCode);
@@ -217,13 +218,14 @@ contract BridgingLogicTest is Test, QuarkBuilderTest {
                 sender: address(0xb0b),
                 recipient: address(0xceecee),
                 blockTimestamp: BLOCK_TIMESTAMP,
-                preferAcross: true
+                preferAcross: true,
+                paymentAssetSymbol: "USD"
             }), // transfer 5 USDC on chain 8453 to 0xceecee
             chainAccountsList_(6e6), // holding 6 USDC in total across chains 1, 8453
-            paymentUsd_()
+            quote_()
         );
 
-        assertEq(result.paymentCurrency, "usd", "usd currency");
+        assertEq(result.paymentCurrency, "USD", "usd currency");
 
         // Check the quark operations
         assertEq(result.quarkOperations.length, 2, "two operations");

--- a/test/builder/QuarkBuilderCometBorrow.t.sol
+++ b/test/builder/QuarkBuilderCometBorrow.t.sol
@@ -410,8 +410,8 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
         assertEq(result.quarkOperations[1].scriptAddress, quotePayAddress, "script address[1] is the quote pay address");
         assertEq(
             result.quarkOperations[1].scriptCalldata,
-            abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 1.1e6, QUOTE_ID),
-            "calldata is QuotePay.pay(address(0xa11ce), USDC_1, 1.1e6, QUOTE_ID);"
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 1.1e6, QUOTE_ID),
+            "calldata is QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT, USDC_1, 1.1e6, QUOTE_ID);"
         );
         assertEq(result.quarkOperations[1].scriptSources.length, 1, "one script source");
         assertEq(result.quarkOperations[1].scriptSources[0], type(QuotePay).creationCode);
@@ -562,12 +562,12 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
             2e6
         );
         // Note: Only chain 1 is used, so the payment is only for the chain 1 cost (1.5e6 USDC)
-        // TODO: The payee should be Bob, but we don't currently handle multi accounts well
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 1.5e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 1.5e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([cometSupplyMultipleAssetsAndBorrowAddress, quotePayAddress], [CometSupplyMultipleAssetsAndBorrow.run(COMET_1_USDC, [LINK_1], [1e18], USDC_1, 2e6), QuotePay.pay(address(0xb0b), USDC_1, 1.5e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([cometSupplyMultipleAssetsAndBorrowAddress, quotePayAddress], [CometSupplyMultipleAssetsAndBorrow.run(COMET_1_USDC, [LINK_1], [1e18], USDC_1, 2e6), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT, USDC_1, 1.5e6, QUOTE_ID)]);"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(CometSupplyMultipleAssetsAndBorrow).creationCode);
@@ -696,11 +696,12 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
             usdc_(1)
         );
         // Covers the quote for both chains
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.3e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.3e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 2.2e6, 6, 0xa11ce, USDC_1), QuotePay.pay(address(0xa11ce), USDC_1, 0.3e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 2.2e6, 6, 0xa11ce, USDC_1), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.3e6, QUOTE_ID)]);"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(CCTPBridgeActions).creationCode);

--- a/test/builder/QuarkBuilderCometBorrow.t.sol
+++ b/test/builder/QuarkBuilderCometBorrow.t.sol
@@ -15,6 +15,7 @@ import {CometSupplyMultipleAssetsAndBorrow} from "src/DeFiScripts.sol";
 import {Paycall} from "src/Paycall.sol";
 import {Strings} from "src/builder/Strings.sol";
 import {Multicall} from "src/Multicall.sol";
+import {QuotePay} from "src/QuotePay.sol";
 import {WrapperActions} from "src/WrapperScripts.sol";
 
 contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
@@ -319,7 +320,13 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testBorrowWithPaycall() public {
+    function testCometBorrowWithQuotePay() public {
+        QuarkBuilder builder = new QuarkBuilder();
+
+        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
+        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.1e6});
+        maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 1e6}); // max cost on base is 1 USDC
+
         string[] memory collateralAssetSymbols = new string[](1);
         collateralAssetSymbols[0] = "LINK";
 
@@ -332,31 +339,28 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
             account: address(0xa11ce),
             nonceSecret: bytes32(uint256(12)),
             assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: Arrays.uintArray(1e6, 0, 10e18, 0), // user has 1 USDC, 10 LINK
+            assetBalances: Arrays.uintArray(3e6, 0, 0, 0), // 3 USDC on mainnet
             cometPortfolios: emptyCometPortfolios_(),
             morphoPortfolios: emptyMorphoPortfolios_(),
             morphoVaultPortfolios: emptyMorphoVaultPortfolios_()
         });
         chainPortfolios[1] = ChainPortfolio({
             chainId: 8453,
-            account: address(0xb0b),
+            account: address(0xa11ce),
             nonceSecret: bytes32(uint256(2)),
             assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: Arrays.uintArray(0, 0, 0, 0),
+            assetBalances: Arrays.uintArray(0, 0, 5e18, 0), // 5 LINK on chain 8453
             cometPortfolios: emptyCometPortfolios_(),
             morphoPortfolios: emptyMorphoPortfolios_(),
             morphoVaultPortfolios: emptyMorphoVaultPortfolios_()
         });
 
-        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
-        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.1e6});
-
-        QuarkBuilder builder = new QuarkBuilder();
+        // Borrow happens on chain 8453, but quote pay happens on chain 1
         QuarkBuilder.BuilderResult memory result = builder.cometBorrow(
             borrowIntent_(
                 1e6,
-                "USDC",
-                1,
+                "USDT",
+                8453,
                 collateralAmounts, // [1e18]
                 collateralAssetSymbols // [LINK]
             ),
@@ -366,61 +370,68 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
 
         address cometSupplyMultipleAssetsAndBorrowAddress =
             CodeJarHelper.getCodeAddress(type(CometSupplyMultipleAssetsAndBorrow).creationCode);
-        address paycallAddress = paycallUsdc_(1);
+        address quotePayAddress = CodeJarHelper.getCodeAddress(type(QuotePay).creationCode);
 
         assertEq(result.paymentCurrency, "usdc", "usdc currency");
 
         // Check the quark operations
-        assertEq(result.quarkOperations.length, 1, "one operation");
+        // First operation
+        assertEq(result.quarkOperations.length, 2, "two operations");
         assertEq(
             result.quarkOperations[0].scriptAddress,
-            paycallAddress,
-            "script address is correct given the code jar address on mainnet"
+            cometSupplyMultipleAssetsAndBorrowAddress,
+            "script address[0] is the borrow actions address"
         );
 
         address[] memory collateralTokens = new address[](1);
-        collateralTokens[0] = link_(1);
+        collateralTokens[0] = link_(8453);
 
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(
-                Paycall.run.selector,
-                cometSupplyMultipleAssetsAndBorrowAddress,
-                abi.encodeWithSelector(
-                    CometSupplyMultipleAssetsAndBorrow.run.selector,
-                    cometUsdc_(1),
-                    collateralTokens,
-                    collateralAmounts,
-                    usdc_(1),
-                    1e6
-                ),
-                0.1e6
+                CometSupplyMultipleAssetsAndBorrow.run.selector,
+                cometUsdc_(1),
+                collateralTokens,
+                collateralAmounts,
+                usdt_(8453),
+                1e6
             ),
-            "calldata is Paycall.run(CometSupplyMultipleAssetsAndBorrow.run(COMET_1_USDC, [LINK_1], [1e18], USDC_1, 1e6), 0.1e6);"
+            "calldata is CometSupplyMultipleAssetsAndBorrow.run(COMET_1_USDC, [LINK_8453], [1e18], USDT_8453, 1e6);"
         );
-        assertEq(result.quarkOperations[0].scriptSources.length, 2);
+        assertEq(result.quarkOperations[0].scriptSources.length, 1, "one script source");
         assertEq(result.quarkOperations[0].scriptSources[0], type(CometSupplyMultipleAssetsAndBorrow).creationCode);
-        assertEq(
-            result.quarkOperations[0].scriptSources[1],
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
-        );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
         );
-        assertEq(result.quarkOperations[0].nonce, chainPortfolios[0].nonceSecret, "unexpected nonce");
+        assertEq(result.quarkOperations[0].nonce, chainPortfolios[1].nonceSecret, "unexpected nonce");
         assertEq(result.quarkOperations[0].isReplayable, false, "isReplayable is false");
 
-        // check the actions
-        assertEq(result.actions.length, 1, "one action");
-        assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
+        // second operation
+        assertEq(result.quarkOperations[1].scriptAddress, quotePayAddress, "script address[1] is the quote pay address");
+        assertEq(
+            result.quarkOperations[1].scriptCalldata,
+            abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 1.1e6, QUOTE_ID),
+            "calldata is QuotePay.pay(address(0xa11ce), USDC_1, 1.1e6, QUOTE_ID);"
+        );
+        assertEq(result.quarkOperations[1].scriptSources.length, 1, "one script source");
+        assertEq(result.quarkOperations[1].scriptSources[0], type(QuotePay).creationCode);
+        assertEq(
+            result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
+        );
+        assertEq(result.quarkOperations[1].nonce, chainPortfolios[0].nonceSecret, "unexpected nonce");
+        assertEq(result.quarkOperations[1].isReplayable, false, "isReplayable is false");
+
+        // Check the actions
+        assertEq(result.actions.length, 2, "two actions");
+        // first action
+        assertEq(result.actions[0].chainId, 8453, "operation is on chainid 8453");
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BORROW", "action type is 'BORROW'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment max is set to .1e6 in this test case");
-        assertEq(result.actions[0].nonceSecret, chainPortfolios[0].nonceSecret, "unexpected nonce secret");
+        assertEq(result.actions[0].paymentToken, USDC_8453, "payment token is USDC on Base");
+        assertEq(result.actions[0].paymentMaxCost, 1e6, "payment should have max cost of 1e6");
+        assertEq(result.actions[0].nonceSecret, chainPortfolios[1].nonceSecret, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
-
         uint256[] memory collateralTokenPrices = new uint256[](1);
         collateralTokenPrices[0] = LINK_PRICE;
 
@@ -429,18 +440,43 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
             abi.encode(
                 Actions.BorrowActionContext({
                     amount: 1e6,
-                    assetSymbol: "USDC",
-                    chainId: 1,
+                    assetSymbol: "USDT",
+                    chainId: 8453,
                     collateralAmounts: collateralAmounts,
                     collateralTokenPrices: collateralTokenPrices,
                     collateralTokens: collateralTokens,
                     collateralAssetSymbols: collateralAssetSymbols,
                     comet: cometUsdc_(1),
-                    price: USDC_PRICE,
-                    token: usdc_(1)
+                    price: USDT_PRICE,
+                    token: usdt_(8453)
                 })
             ),
             "action context encoded from BorrowActionContext"
+        );
+
+        // second action
+        assertEq(result.actions[1].chainId, 1, "operation is on chainid 1");
+        assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
+        assertEq(result.actions[1].actionType, "QUOTE_PAY", "action type is 'QUOTE_PAY'");
+        assertEq(result.actions[1].paymentMethod, "QUOTE_CALL", "payment method is 'QUOTE_CALL'");
+        assertEq(result.actions[1].paymentToken, USDC_1, "payment token is USDC on mainnet");
+        assertEq(result.actions[1].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
+        assertEq(result.actions[1].nonceSecret, chainPortfolios[0].nonceSecret, "unexpected nonce secret");
+        assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
+        assertEq(
+            result.actions[1].actionContext,
+            abi.encode(
+                Actions.QuotePayActionContext({
+                    amount: 1.1e6,
+                    assetSymbol: "USDC",
+                    chainId: 1,
+                    price: USDC_PRICE,
+                    token: USDC_1,
+                    payee: address(0xa11ce),
+                    quoteId: QUOTE_ID
+                })
+            ),
+            "action context encoded from QuotePayActionContext"
         );
 
         // TODO: Check the contents of the EIP712 data
@@ -449,10 +485,12 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
+    // DONE
     function testBorrowPayFromBorrow() public {
         QuarkBuilder builder = new QuarkBuilder();
-        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
-        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.5e6}); // action costs .5 USDC
+        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
+        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 1.5e6}); // action costs 1.5 USDC
+        maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 0.5e6}); // action costs 0.5 USDC
 
         uint256[] memory collateralAmounts = new uint256[](1);
         collateralAmounts[0] = 1e18;
@@ -484,7 +522,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
 
         QuarkBuilder.BuilderResult memory result = builder.cometBorrow(
             borrowIntent_(
-                1e6,
+                2e6,
                 "USDC",
                 1,
                 collateralAmounts, // [1e18]
@@ -496,7 +534,8 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
 
         address cometSupplyMultipleAssetsAndBorrowAddress =
             CodeJarHelper.getCodeAddress(type(CometSupplyMultipleAssetsAndBorrow).creationCode);
-        address paycallAddress = paycallUsdc_(1);
+        address multicallAddress = CodeJarHelper.getCodeAddress(type(Multicall).creationCode);
+        address quotePayAddress = CodeJarHelper.getCodeAddress(type(QuotePay).creationCode);
 
         assertEq(result.paymentCurrency, "usdc", "usdc currency");
 
@@ -507,32 +546,33 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
         assertEq(result.quarkOperations.length, 1, "one operation");
         assertEq(
             result.quarkOperations[0].scriptAddress,
-            paycallAddress,
+            multicallAddress,
             "script address is correct given the code jar address on mainnet"
         );
+        address[] memory callContracts = new address[](2);
+        callContracts[0] = cometSupplyMultipleAssetsAndBorrowAddress;
+        callContracts[1] = quotePayAddress;
+        bytes[] memory callDatas = new bytes[](2);
+        callDatas[0] = abi.encodeWithSelector(
+            CometSupplyMultipleAssetsAndBorrow.run.selector,
+            cometUsdc_(1),
+            collateralTokens,
+            collateralAmounts,
+            usdc_(1),
+            2e6
+        );
+        // Note: Only chain 1 is used, so the payment is only for the chain 1 cost (1.5e6 USDC)
+        // TODO: The payee should be Bob, but we don't currently handle multi accounts well
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 1.5e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                cometSupplyMultipleAssetsAndBorrowAddress,
-                abi.encodeWithSelector(
-                    CometSupplyMultipleAssetsAndBorrow.run.selector,
-                    cometUsdc_(1),
-                    collateralTokens,
-                    collateralAmounts,
-                    usdc_(1),
-                    1e6
-                ),
-                0.5e6
-            ),
-            "calldata is Paycall.run(CometSupplyMultipleAssetsAndBorrow.run.selector, (COMET_1_USDC, [LINK_1], [1e18], USDC_1, 1e6), .5e6);"
+            abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
+            "calldata is Multicall.run([cometSupplyMultipleAssetsAndBorrowAddress, quotePayAddress], [CometSupplyMultipleAssetsAndBorrow.run(COMET_1_USDC, [LINK_1], [1e18], USDC_1, 2e6), QuotePay.pay(address(0xb0b), USDC_1, 1.5e6, QUOTE_ID)]);"
         );
-        assertEq(result.quarkOperations[0].scriptSources.length, 2);
+        assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(CometSupplyMultipleAssetsAndBorrow).creationCode);
-        assertEq(
-            result.quarkOperations[0].scriptSources[1],
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
-        );
+        assertEq(result.quarkOperations[0].scriptSources[1], type(QuotePay).creationCode);
+        assertEq(result.quarkOperations[0].scriptSources[2], type(Multicall).creationCode);
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
         );
@@ -546,7 +586,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].actionType, "BORROW", "action type is 'BORROW'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
         assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 0.5e6, "payment max is set to .5e6 in this test case");
+        assertEq(result.actions[0].paymentMaxCost, 1.5e6, "payment max is set to 1.5e6 in this test case");
         assertEq(result.actions[0].nonceSecret, chainPortfolios[0].nonceSecret, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
 
@@ -557,7 +597,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
             result.actions[0].actionContext,
             abi.encode(
                 Actions.BorrowActionContext({
-                    amount: 1e6,
+                    amount: 2e6,
                     assetSymbol: "USDC",
                     chainId: 1,
                     collateralAmounts: collateralAmounts,
@@ -578,204 +618,7 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testBorrowWithBridgedPaymentToken() public {
-        QuarkBuilder builder = new QuarkBuilder();
-
-        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
-        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.1e6});
-        maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 1e6}); // max cost on base is 1 USDC
-
-        string[] memory collateralAssetSymbols = new string[](1);
-        collateralAssetSymbols[0] = "LINK";
-
-        uint256[] memory collateralAmounts = new uint256[](1);
-        collateralAmounts[0] = 1e18;
-
-        ChainPortfolio[] memory chainPortfolios = new ChainPortfolio[](2);
-        chainPortfolios[0] = ChainPortfolio({
-            chainId: 1,
-            account: address(0xa11ce),
-            nonceSecret: bytes32(uint256(12)),
-            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: Arrays.uintArray(3e6, 0, 0, 0), // 3 USDC on mainnet
-            cometPortfolios: emptyCometPortfolios_(),
-            morphoPortfolios: emptyMorphoPortfolios_(),
-            morphoVaultPortfolios: emptyMorphoVaultPortfolios_()
-        });
-        chainPortfolios[1] = ChainPortfolio({
-            chainId: 8453,
-            account: address(0xa11ce),
-            nonceSecret: bytes32(uint256(2)),
-            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: Arrays.uintArray(0, 0, 5e18, 0),
-            cometPortfolios: emptyCometPortfolios_(),
-            morphoPortfolios: emptyMorphoPortfolios_(),
-            morphoVaultPortfolios: emptyMorphoVaultPortfolios_()
-        });
-
-        QuarkBuilder.BuilderResult memory result = builder.cometBorrow(
-            borrowIntent_(
-                1e6,
-                "USDT",
-                8453,
-                collateralAmounts, // [1e18]
-                collateralAssetSymbols // [LINK]
-            ),
-            chainAccountsFromChainPortfolios(chainPortfolios),
-            paymentUsdc_(maxCosts)
-        );
-
-        address paycallAddress = paycallUsdc_(1);
-        address paycallAddressBase = paycallUsdc_(8453);
-        address cctpBridgeActionsAddress = CodeJarHelper.getCodeAddress(type(CCTPBridgeActions).creationCode);
-        address cometSupplyMultipleAssetsAndBorrowAddress =
-            CodeJarHelper.getCodeAddress(type(CometSupplyMultipleAssetsAndBorrow).creationCode);
-
-        assertEq(result.paymentCurrency, "usdc", "usdc currency");
-
-        // Check the quark operations
-        // first operation
-        assertEq(result.quarkOperations.length, 2, "two operations");
-        assertEq(
-            result.quarkOperations[0].scriptAddress,
-            paycallAddress,
-            "script address is correct given the code jar address on base"
-        );
-        assertEq(
-            result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                cctpBridgeActionsAddress,
-                abi.encodeWithSelector(
-                    CCTPBridgeActions.bridgeUSDC.selector,
-                    address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
-                    1e6,
-                    6,
-                    bytes32(uint256(uint160(0xa11ce))),
-                    usdc_(1)
-                ),
-                0.1e6
-            ),
-            "calldata is Paycall.run(CCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 1e6, 6, 0xa11ce, USDC_1)), 0.1e6);"
-        );
-        assertEq(result.quarkOperations[0].scriptSources.length, 2);
-        assertEq(result.quarkOperations[0].scriptSources[0], type(CCTPBridgeActions).creationCode);
-        assertEq(
-            result.quarkOperations[0].scriptSources[1],
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
-        );
-        assertEq(
-            result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
-        );
-        assertEq(result.quarkOperations[0].nonce, chainPortfolios[0].nonceSecret, "unexpected nonce");
-        assertEq(result.quarkOperations[0].isReplayable, false, "isReplayable is false");
-
-        // second operation
-        assertEq(
-            result.quarkOperations[1].scriptAddress,
-            paycallAddressBase,
-            "script address[1] has been wrapped with paycall address"
-        );
-
-        address[] memory collateralTokens = new address[](1);
-        collateralTokens[0] = link_(8453);
-
-        assertEq(
-            result.quarkOperations[1].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                cometSupplyMultipleAssetsAndBorrowAddress,
-                abi.encodeWithSelector(
-                    CometSupplyMultipleAssetsAndBorrow.run.selector,
-                    cometUsdc_(1),
-                    collateralTokens,
-                    collateralAmounts,
-                    usdt_(8453),
-                    1e6
-                ),
-                1e6
-            ),
-            "calldata is Paycall.run(CometSupplyMultipleAssetsAndBorrow.run(COMET_1_USDC, [LINK_8453], [1e18], USDT_8453, 1e6), 1e6);"
-        );
-        assertEq(result.quarkOperations[1].scriptSources.length, 2);
-        assertEq(result.quarkOperations[1].scriptSources[0], type(CometSupplyMultipleAssetsAndBorrow).creationCode);
-        assertEq(
-            result.quarkOperations[1].scriptSources[1],
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_8453, USDC_8453))
-        );
-        assertEq(
-            result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
-        );
-        assertEq(result.quarkOperations[1].nonce, chainPortfolios[1].nonceSecret, "unexpected nonce");
-        assertEq(result.quarkOperations[1].isReplayable, false, "isReplayable is false");
-
-        // Check the actions
-        assertEq(result.actions.length, 2, "two actions");
-        // first action
-        assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
-        assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
-        assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
-        assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
-        assertEq(result.actions[0].nonceSecret, chainPortfolios[0].nonceSecret, "unexpected nonce secret");
-        assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
-        assertEq(
-            result.actions[0].actionContext,
-            abi.encode(
-                Actions.BridgeActionContext({
-                    price: USDC_PRICE,
-                    token: USDC_1,
-                    assetSymbol: "USDC",
-                    inputAmount: 1e6,
-                    outputAmount: 1e6,
-                    chainId: 1,
-                    recipient: address(0xa11ce),
-                    destinationChainId: 8453,
-                    bridgeType: Actions.BRIDGE_TYPE_CCTP
-                })
-            ),
-            "action context encoded from BridgeActionContext"
-        );
-        // second action
-        assertEq(result.actions[1].chainId, 8453, "operation is on chainid 8453");
-        assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
-        assertEq(result.actions[1].actionType, "BORROW", "action type is 'BORROW'");
-        assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
-        assertEq(result.actions[1].paymentMaxCost, 1e6, "payment should have max cost of 1e6");
-        assertEq(result.actions[1].nonceSecret, chainPortfolios[1].nonceSecret, "unexpected nonce secret");
-        assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
-
-        uint256[] memory collateralTokenPrices = new uint256[](1);
-        collateralTokenPrices[0] = LINK_PRICE;
-
-        assertEq(
-            result.actions[1].actionContext,
-            abi.encode(
-                Actions.BorrowActionContext({
-                    amount: 1e6,
-                    assetSymbol: "USDT",
-                    chainId: 8453,
-                    collateralAmounts: collateralAmounts,
-                    collateralTokenPrices: collateralTokenPrices,
-                    collateralTokens: collateralTokens,
-                    collateralAssetSymbols: collateralAssetSymbols,
-                    comet: cometUsdc_(1),
-                    price: USDT_PRICE,
-                    token: usdt_(8453)
-                })
-            ),
-            "action context encoded from BorrowActionContext"
-        );
-
-        // TODO: Check the contents of the EIP712 data
-        assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
-        assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");
-        assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
-    }
-
-    function testBorrowWithBridgedcollateralAsset() public {
+    function testBorrowWithBridgedCollateralAsset() public {
         QuarkBuilder builder = new QuarkBuilder();
 
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
@@ -823,45 +666,46 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
             paymentUsdc_(maxCosts)
         );
 
-        address paycallAddress = paycallUsdc_(1);
-        address paycallAddressBase = paycallUsdc_(8453);
         address cctpBridgeActionsAddress = CodeJarHelper.getCodeAddress(type(CCTPBridgeActions).creationCode);
         address cometSupplyMultipleAssetsAndBorrowAddress =
             CodeJarHelper.getCodeAddress(type(CometSupplyMultipleAssetsAndBorrow).creationCode);
+        address multicallAddress = CodeJarHelper.getCodeAddress(type(Multicall).creationCode);
+        address quotePayAddress = CodeJarHelper.getCodeAddress(type(QuotePay).creationCode);
 
         assertEq(result.paymentCurrency, "usdc", "usdc currency");
 
         // Check the quark operations
         // first operation
         assertEq(result.quarkOperations.length, 2, "two operations");
+
         assertEq(
             result.quarkOperations[0].scriptAddress,
-            paycallAddress,
-            "script address is correct given the code jar address on base"
+            multicallAddress,
+            "script address[0] has been wrapped with multicall address"
         );
+        address[] memory callContracts = new address[](2);
+        callContracts[0] = cctpBridgeActionsAddress;
+        callContracts[1] = quotePayAddress;
+        bytes[] memory callDatas = new bytes[](2);
+        callDatas[0] = abi.encodeWithSelector(
+            CCTPBridgeActions.bridgeUSDC.selector,
+            address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
+            2e6, // 2e6 supplied
+            6,
+            bytes32(uint256(uint160(0xa11ce))),
+            usdc_(1)
+        );
+        // Covers the quote for both chains
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.3e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                cctpBridgeActionsAddress,
-                abi.encodeWithSelector(
-                    CCTPBridgeActions.bridgeUSDC.selector,
-                    address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
-                    2.2e6, // 2e6 supplied + 0.2e6 max cost on Base
-                    6,
-                    bytes32(uint256(uint160(0xa11ce))),
-                    usdc_(1)
-                ),
-                0.1e6
-            ),
-            "calldata is Paycall.run(CCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 2.2e6, 6, 0xa11ce, USDC_1)), 0.1e6);"
+            abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
+            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 2.2e6, 6, 0xa11ce, USDC_1), QuotePay.pay(address(0xa11ce), USDC_1, 0.3e6, QUOTE_ID)]);"
         );
-        assertEq(result.quarkOperations[0].scriptSources.length, 2);
+        assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(CCTPBridgeActions).creationCode);
-        assertEq(
-            result.quarkOperations[0].scriptSources[1],
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
-        );
+        assertEq(result.quarkOperations[0].scriptSources[1], type(QuotePay).creationCode);
+        assertEq(result.quarkOperations[0].scriptSources[2], type(Multicall).creationCode);
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
         );
@@ -871,8 +715,8 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
         // second operation
         assertEq(
             result.quarkOperations[1].scriptAddress,
-            paycallAddressBase,
-            "script address[1] has been wrapped with paycall address"
+            cometSupplyMultipleAssetsAndBorrowAddress,
+            "script address is correct"
         );
 
         address[] memory collateralTokens = new address[](1);
@@ -881,26 +725,17 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
         assertEq(
             result.quarkOperations[1].scriptCalldata,
             abi.encodeWithSelector(
-                Paycall.run.selector,
-                cometSupplyMultipleAssetsAndBorrowAddress,
-                abi.encodeWithSelector(
-                    CometSupplyMultipleAssetsAndBorrow.run.selector,
-                    cometUsdc_(1),
-                    collateralTokens,
-                    collateralAmounts,
-                    weth_(8453),
-                    1e18
-                ),
-                0.2e6
+                CometSupplyMultipleAssetsAndBorrow.run.selector,
+                cometUsdc_(1),
+                collateralTokens,
+                collateralAmounts,
+                weth_(8453),
+                1e18
             ),
-            "calldata is Paycall.run(CometSupplyMultipleAssetsAndBorrow.run(COMET_1_USDC, [USDC_8453], [2e6], WETH_8453, 1e18), 0.2e6);"
+            "calldata is CometSupplyMultipleAssetsAndBorrow.run(COMET_1_USDC, [USDC_8453], [2e6], WETH_8453, 1e18);"
         );
-        assertEq(result.quarkOperations[1].scriptSources.length, 2);
+        assertEq(result.quarkOperations[1].scriptSources.length, 1, "one script source");
         assertEq(result.quarkOperations[1].scriptSources[0], type(CometSupplyMultipleAssetsAndBorrow).creationCode);
-        assertEq(
-            result.quarkOperations[1].scriptSources[1],
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_8453, USDC_8453))
-        );
         assertEq(
             result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
         );
@@ -925,8 +760,8 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
                     price: USDC_PRICE,
                     token: USDC_1,
                     assetSymbol: "USDC",
-                    inputAmount: 2.2e6,
-                    outputAmount: 2.2e6,
+                    inputAmount: 2e6,
+                    outputAmount: 2e6,
                     chainId: 1,
                     recipient: address(0xa11ce),
                     destinationChainId: 8453,

--- a/test/builder/QuarkBuilderCometRepay.t.sol
+++ b/test/builder/QuarkBuilderCometRepay.t.sol
@@ -76,7 +76,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
     function testCometRepayNotEnoughPaymentToken() public {
         QuarkBuilder builder = new QuarkBuilder();
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
-        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.5e6}); // action costs .5 USDC
+        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.5e6}); // action costs 0.5 USDC
 
         uint256[] memory collateralAmounts = new uint256[](0);
         string[] memory collateralAssetSymbols = new string[](0);
@@ -94,7 +94,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         });
 
         // Need 0.5e6 USDC to pay the quote but Alice only has 0.4e6 USDC
-        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "usdc"));
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.ImpossibleToConstructQuotePay.selector, "usdc"));
         builder.cometRepay(
             repayIntent_(1, cometWeth_(1), "WETH", 1e18, collateralAssetSymbols, collateralAmounts),
             chainAccountsFromChainPortfolios(chainPortfolios),

--- a/test/builder/QuarkBuilderCometRepay.t.sol
+++ b/test/builder/QuarkBuilderCometRepay.t.sol
@@ -430,11 +430,12 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
             weth_(1),
             1e18
         );
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.5e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.5e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([cometRepayAndWithdrawMultipleAssetsAddress, quotePayAddress], [CometRepayAndWithdrawMultipleAssets.run(cometWeth_(1), [USDC_1], [1e6], WETH_1, 1e18), QuotePay.pay(address(0xa11ce), USDC_1, 0.5e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([cometRepayAndWithdrawMultipleAssetsAddress, quotePayAddress], [CometRepayAndWithdrawMultipleAssets.run(cometWeth_(1), [USDC_1], [1e6], WETH_1, 1e18), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.5e6, QUOTE_ID)]);"
         );
 
         assertEq(result.quarkOperations[0].scriptSources.length, 3);
@@ -562,11 +563,12 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
             bytes32(uint256(uint160(0xa11ce))),
             usdc_(1)
         );
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.3e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.3e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 2e6, 6, 0xa11ce, USDC_1), QuotePay.pay(address(0xa11ce), USDC_1, 0.3e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 2e6, 6, 0xa11ce, USDC_1), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.3e6, QUOTE_ID)]);"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(CCTPBridgeActions).creationCode);
@@ -743,11 +745,12 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
             usdc_(1),
             type(uint256).max
         );
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.1e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([cometRepayAndWithdrawMultipleAssetsAddress, quotePayAddress], [CometRepayAndWithdrawMultipleAssets.run(cometUsdc_(1), [], [], USDC_1, uint256.max), QuotePay.pay(address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([cometRepayAndWithdrawMultipleAssetsAddress, quotePayAddress], [CometRepayAndWithdrawMultipleAssets.run(cometUsdc_(1), [], [], USDC_1, uint256.max), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.1e6, QUOTE_ID)]);"
         );
 
         assertEq(result.quarkOperations[0].scriptSources.length, 3);
@@ -882,11 +885,12 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
             usdc_(1)
         );
         // Covers the quote for both chains
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.2e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.2e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 10.01e6, 6, 0xa11ce, USDC_1), QuotePay.pay(address(0xa11ce), USDC_1, 0.2e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 10.01e6, 6, 0xa11ce, USDC_1), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.2e6, QUOTE_ID)]);"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(CCTPBridgeActions).creationCode);

--- a/test/builder/QuarkBuilderCometRepay.t.sol
+++ b/test/builder/QuarkBuilderCometRepay.t.sol
@@ -16,6 +16,7 @@ import {Multicall} from "src/Multicall.sol";
 import {Paycall} from "src/Paycall.sol";
 import {Strings} from "src/builder/Strings.sol";
 import {WrapperActions} from "src/WrapperScripts.sol";
+import {QuotePay} from "src/QuotePay.sol";
 
 contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
     function repayIntent_(
@@ -65,7 +66,6 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         QuarkBuilder builder = new QuarkBuilder();
 
         vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.FundsUnavailable.selector, "USDC", 1e6, 0));
-
         builder.cometRepay(
             repayIntent_(1, cometUsdc_(1), "USDC", 1e6, collateralAssetSymbols, collateralAmounts), // attempting to repay 1 USDC
             chainAccountsList_(0e6), // but user has 0 USDC
@@ -73,7 +73,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         );
     }
 
-    function testCometRepayMaxCostTooHigh() public {
+    function testCometRepayNotEnoughPaymentToken() public {
         QuarkBuilder builder = new QuarkBuilder();
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
         maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.5e6}); // action costs .5 USDC
@@ -93,7 +93,8 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
             morphoVaultPortfolios: emptyMorphoVaultPortfolios_()
         });
 
-        vm.expectRevert(abi.encodeWithSelector(Actions.NotEnoughFundsToBridge.selector, "usdc", 0.1e6, 0.1e6));
+        // Need 0.5e6 USDC to pay the quote but Alice only has 0.4e6 USDC
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "usdc"));
         builder.cometRepay(
             repayIntent_(1, cometWeth_(1), "WETH", 1e18, collateralAssetSymbols, collateralAmounts),
             chainAccountsFromChainPortfolios(chainPortfolios),
@@ -348,137 +349,6 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testCometRepayWithPaycall() public {
-        string[] memory collateralAssetSymbols = new string[](1);
-        collateralAssetSymbols[0] = "LINK";
-
-        uint256[] memory collateralAmounts = new uint256[](1);
-        collateralAmounts[0] = 1e18;
-
-        ChainPortfolio[] memory chainPortfolios = new ChainPortfolio[](2);
-        chainPortfolios[0] = ChainPortfolio({
-            chainId: 1,
-            account: address(0xa11ce),
-            nonceSecret: bytes32(uint256(12)),
-            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: Arrays.uintArray(2e6, 0, 0, 0),
-            cometPortfolios: emptyCometPortfolios_(),
-            morphoPortfolios: emptyMorphoPortfolios_(),
-            morphoVaultPortfolios: emptyMorphoVaultPortfolios_()
-        });
-        chainPortfolios[1] = ChainPortfolio({
-            chainId: 8453,
-            account: address(0xb0b),
-            nonceSecret: bytes32(uint256(2)),
-            assetSymbols: Arrays.stringArray("USDC", "USDT", "LINK", "WETH"),
-            assetBalances: Arrays.uintArray(0, 0, 0, 0),
-            cometPortfolios: emptyCometPortfolios_(),
-            morphoPortfolios: emptyMorphoPortfolios_(),
-            morphoVaultPortfolios: emptyMorphoVaultPortfolios_()
-        });
-
-        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
-        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.1e6});
-
-        QuarkBuilder builder = new QuarkBuilder();
-        QuarkBuilder.BuilderResult memory result = builder.cometRepay(
-            repayIntent_(
-                1,
-                cometUsdc_(1),
-                "USDC",
-                1e6, // repaying 1 USDC
-                collateralAssetSymbols,
-                collateralAmounts // withdrawing 1 LINK
-            ),
-            chainAccountsFromChainPortfolios(chainPortfolios),
-            paymentUsdc_(maxCosts) // and paying with USDC
-        );
-
-        address cometRepayAndWithdrawMultipleAssetsAddress =
-            CodeJarHelper.getCodeAddress(type(CometRepayAndWithdrawMultipleAssets).creationCode);
-        address paycallAddress = paycallUsdc_(1);
-
-        assertEq(result.paymentCurrency, "usdc", "usdc currency");
-
-        // Check the quark operations
-        assertEq(result.quarkOperations.length, 1, "one operation");
-        assertEq(
-            result.quarkOperations[0].scriptAddress,
-            paycallAddress,
-            "script address is correct given the code jar address on mainnet"
-        );
-
-        address[] memory collateralTokens = new address[](1);
-        collateralTokens[0] = link_(1);
-
-        assertEq(
-            result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                cometRepayAndWithdrawMultipleAssetsAddress,
-                abi.encodeWithSelector(
-                    CometRepayAndWithdrawMultipleAssets.run.selector,
-                    cometUsdc_(1),
-                    collateralTokens,
-                    collateralAmounts,
-                    usdc_(1),
-                    1e6
-                ),
-                0.1e6
-            ),
-            "calldata is Paycall.run(CometRepayAndWithdrawMultipleAssets.run(cometUsdc_(1), [LINK_1], [1e18], USDC_1, 1e6), 0.1e6);"
-        );
-        assertEq(result.quarkOperations[0].scriptSources.length, 2);
-        assertEq(result.quarkOperations[0].scriptSources[0], type(CometRepayAndWithdrawMultipleAssets).creationCode);
-        assertEq(
-            result.quarkOperations[0].scriptSources[1],
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
-        );
-        assertEq(
-            result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
-        );
-        assertEq(result.quarkOperations[0].nonce, chainPortfolios[0].nonceSecret, "unexpected nonce");
-        assertEq(result.quarkOperations[0].isReplayable, false, "isReplayable is false");
-
-        // check the actions
-        assertEq(result.actions.length, 1, "one action");
-        assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
-        assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
-        assertEq(result.actions[0].actionType, "REPAY", "action type is 'REPAY'");
-        assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment max is set to .1e6 in this test case");
-        assertEq(result.actions[0].nonceSecret, chainPortfolios[0].nonceSecret, "unexpected nonce secret");
-        assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
-
-        uint256[] memory collateralTokenPrices = new uint256[](1);
-        collateralTokenPrices[0] = LINK_PRICE;
-
-        assertEq(
-            result.actions[0].actionContext,
-            abi.encode(
-                Actions.RepayActionContext({
-                    amount: 1e6,
-                    assetSymbol: "USDC",
-                    chainId: 1,
-                    collateralAmounts: collateralAmounts,
-                    collateralAssetSymbols: collateralAssetSymbols,
-                    collateralTokenPrices: collateralTokenPrices,
-                    collateralTokens: collateralTokens,
-                    comet: cometUsdc_(1),
-                    price: USDC_PRICE,
-                    token: usdc_(1)
-                })
-            ),
-            "action context encoded from RepayActionContext"
-        );
-
-        // TODO: Check the contents of the EIP712 data
-        assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
-        assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");
-        assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
-    }
-
     // pay for a transaction with funds currently supplied as collateral
     function testCometRepayPayFromWithdraw() public {
         QuarkBuilder builder = new QuarkBuilder();
@@ -533,7 +403,8 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
 
         address cometRepayAndWithdrawMultipleAssetsAddress =
             CodeJarHelper.getCodeAddress(type(CometRepayAndWithdrawMultipleAssets).creationCode);
-        address paycallAddress = paycallUsdc_(1);
+        address quotePayAddress = CodeJarHelper.getCodeAddress(type(QuotePay).creationCode);
+        address multicallAddress = CodeJarHelper.getCodeAddress(type(Multicall).creationCode);
 
         assertEq(result.paymentCurrency, "usdc", "usdc currency");
 
@@ -544,33 +415,32 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         assertEq(result.quarkOperations.length, 1, "one operation");
         assertEq(
             result.quarkOperations[0].scriptAddress,
-            paycallAddress,
-            "script address is correct given the code jar address on mainnet"
+            multicallAddress,
+            "script address[0] has been wrapped with multicall address"
         );
+        address[] memory callContracts = new address[](2);
+        callContracts[0] = cometRepayAndWithdrawMultipleAssetsAddress;
+        callContracts[1] = quotePayAddress;
+        bytes[] memory callDatas = new bytes[](2);
+        callDatas[0] = abi.encodeWithSelector(
+            CometRepayAndWithdrawMultipleAssets.run.selector,
+            cometWeth_(1),
+            collateralTokens,
+            repayIntent.collateralAmounts,
+            weth_(1),
+            1e18
+        );
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.5e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                cometRepayAndWithdrawMultipleAssetsAddress,
-                abi.encodeWithSelector(
-                    CometRepayAndWithdrawMultipleAssets.run.selector,
-                    cometWeth_(1),
-                    collateralTokens,
-                    repayIntent.collateralAmounts,
-                    weth_(1),
-                    1e18
-                ),
-                0.5e6
-            ),
-            "calldata is Paycall.run(CometRepayAndWithdrawMultipleAssets.run(cometWeth_(1), [USDC_1], [1e6], WETH_1, 1e18), 0.5e6);"
+            abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
+            "calldata is Multicall.run([cometRepayAndWithdrawMultipleAssetsAddress, quotePayAddress], [CometRepayAndWithdrawMultipleAssets.run(cometWeth_(1), [USDC_1], [1e6], WETH_1, 1e18), QuotePay.pay(address(0xa11ce), USDC_1, 0.5e6, QUOTE_ID)]);"
         );
 
-        assertEq(result.quarkOperations[0].scriptSources.length, 2);
+        assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(CometRepayAndWithdrawMultipleAssets).creationCode);
-        assertEq(
-            result.quarkOperations[0].scriptSources[1],
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
-        );
+        assertEq(result.quarkOperations[0].scriptSources[1], type(QuotePay).creationCode);
+        assertEq(result.quarkOperations[0].scriptSources[2], type(Multicall).creationCode);
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
         );
@@ -664,11 +534,11 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
             paymentUsdc_(maxCosts)
         );
 
-        address paycallAddress = paycallUsdc_(1);
-        address paycallAddressBase = paycallUsdc_(8453);
         address cctpBridgeActionsAddress = CodeJarHelper.getCodeAddress(type(CCTPBridgeActions).creationCode);
         address cometRepayAndWithdrawMultipleAssetsAddress =
             CodeJarHelper.getCodeAddress(type(CometRepayAndWithdrawMultipleAssets).creationCode);
+        address multicallAddress = CodeJarHelper.getCodeAddress(type(Multicall).creationCode);
+        address quotePayAddress = CodeJarHelper.getCodeAddress(type(QuotePay).creationCode);
 
         assertEq(result.paymentCurrency, "usdc", "usdc currency");
 
@@ -677,32 +547,31 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         assertEq(result.quarkOperations.length, 2, "two operations");
         assertEq(
             result.quarkOperations[0].scriptAddress,
-            paycallAddress,
-            "script address is correct given the code jar address on base"
+            multicallAddress,
+            "script address[0] has been wrapped with multicall address"
         );
+        address[] memory callContracts = new address[](2);
+        callContracts[0] = cctpBridgeActionsAddress;
+        callContracts[1] = quotePayAddress;
+        bytes[] memory callDatas = new bytes[](2);
+        callDatas[0] = abi.encodeWithSelector(
+            CCTPBridgeActions.bridgeUSDC.selector,
+            address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
+            2e6, // 2e6 repaid
+            6,
+            bytes32(uint256(uint160(0xa11ce))),
+            usdc_(1)
+        );
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.3e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                cctpBridgeActionsAddress,
-                abi.encodeWithSelector(
-                    CCTPBridgeActions.bridgeUSDC.selector,
-                    address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
-                    2.2e6, // 2e6 repaid + 0.2e6 max cost on Base
-                    6,
-                    bytes32(uint256(uint160(0xa11ce))),
-                    usdc_(1)
-                ),
-                0.1e6
-            ),
-            "calldata is Paycall.run(CCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 2.2e6, 6, 0xa11ce, USDC_1)), 0.1e6);"
+            abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
+            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 2e6, 6, 0xa11ce, USDC_1), QuotePay.pay(address(0xa11ce), USDC_1, 0.3e6, QUOTE_ID)]);"
         );
-        assertEq(result.quarkOperations[0].scriptSources.length, 2);
+        assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(CCTPBridgeActions).creationCode);
-        assertEq(
-            result.quarkOperations[0].scriptSources[1],
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
-        );
+        assertEq(result.quarkOperations[0].scriptSources[1], type(QuotePay).creationCode);
+        assertEq(result.quarkOperations[0].scriptSources[2], type(Multicall).creationCode);
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
         );
@@ -712,8 +581,8 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         // second operation
         assertEq(
             result.quarkOperations[1].scriptAddress,
-            paycallAddressBase,
-            "script address[1] has been wrapped with paycall address"
+            cometRepayAndWithdrawMultipleAssetsAddress,
+            "script address[1] is correct"
         );
 
         address[] memory collateralTokens = new address[](1);
@@ -722,26 +591,17 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         assertEq(
             result.quarkOperations[1].scriptCalldata,
             abi.encodeWithSelector(
-                Paycall.run.selector,
-                cometRepayAndWithdrawMultipleAssetsAddress,
-                abi.encodeWithSelector(
-                    CometRepayAndWithdrawMultipleAssets.run.selector,
-                    cometUsdc_(8453),
-                    collateralTokens,
-                    collateralAmounts,
-                    usdc_(8453),
-                    2e6
-                ),
-                0.2e6
+                CometRepayAndWithdrawMultipleAssets.run.selector,
+                cometUsdc_(8453),
+                collateralTokens,
+                collateralAmounts,
+                usdc_(8453),
+                2e6
             ),
-            "calldata is Paycall.run(CometRepayAndWithdrawMultipleAssets.run(cometUsdc_(8453), [LINK_8453], [1e18], USDC_8453, 2e6), 0.2e6);"
+            "calldata is CometRepayAndWithdrawMultipleAssets.run(cometUsdc_(8453), [LINK_8453], [1e18], USDC_8453, 2e6);"
         );
-        assertEq(result.quarkOperations[1].scriptSources.length, 2);
+        assertEq(result.quarkOperations[1].scriptSources.length, 1);
         assertEq(result.quarkOperations[1].scriptSources[0], type(CometRepayAndWithdrawMultipleAssets).creationCode);
-        assertEq(
-            result.quarkOperations[1].scriptSources[1],
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_8453, USDC_8453))
-        );
         assertEq(
             result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
         );
@@ -764,8 +624,8 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
             abi.encode(
                 Actions.BridgeActionContext({
                     assetSymbol: "USDC",
-                    inputAmount: 2.2e6,
-                    outputAmount: 2.2e6,
+                    inputAmount: 2e6,
+                    outputAmount: 2e6,
                     bridgeType: Actions.BRIDGE_TYPE_CCTP,
                     chainId: 1,
                     destinationChainId: 8453,
@@ -814,7 +674,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testCometRepayMax() public {
+    function testCometRepayMaxWithQuotePay() public {
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
         maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.1e6});
 
@@ -859,44 +719,41 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
 
         assertEq(result.paymentCurrency, "usdc", "usdc currency");
 
-        address paycallAddress = CodeJarHelper.getCodeAddress(
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
-        );
         address cometRepayAndWithdrawMultipleAssetsAddress =
             CodeJarHelper.getCodeAddress(type(CometRepayAndWithdrawMultipleAssets).creationCode);
+        address multicallAddress = CodeJarHelper.getCodeAddress(type(Multicall).creationCode);
+        address quotePayAddress = CodeJarHelper.getCodeAddress(type(QuotePay).creationCode);
 
         // Check the quark operations
         assertEq(result.quarkOperations.length, 1, "one operation");
         assertEq(
             result.quarkOperations[0].scriptAddress,
-            paycallAddress,
-            "script address is correct given the code jar address on mainnet"
+            multicallAddress,
+            "script address has been wrapped with multicall address"
         );
-
+        address[] memory callContracts = new address[](2);
+        callContracts[0] = cometRepayAndWithdrawMultipleAssetsAddress;
+        callContracts[1] = quotePayAddress;
+        bytes[] memory callDatas = new bytes[](2);
+        callDatas[0] = abi.encodeWithSelector(
+            CometRepayAndWithdrawMultipleAssets.run.selector,
+            cometUsdc_(1),
+            collateralTokens,
+            collateralAmounts,
+            usdc_(1),
+            type(uint256).max
+        );
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                cometRepayAndWithdrawMultipleAssetsAddress,
-                abi.encodeWithSelector(
-                    CometRepayAndWithdrawMultipleAssets.run.selector,
-                    cometUsdc_(1),
-                    collateralTokens,
-                    collateralAmounts,
-                    usdc_(1),
-                    type(uint256).max
-                ),
-                0.1e6
-            ),
-            "calldata is Paycall.run(CometRepayAndWithdrawMultipleAssets.run(cometUsdc_(1), [], [], USDC_1, uint256.max), 0.1e6);"
+            abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
+            "calldata is Multicall.run([cometRepayAndWithdrawMultipleAssetsAddress, quotePayAddress], [CometRepayAndWithdrawMultipleAssets.run(cometUsdc_(1), [], [], USDC_1, uint256.max), QuotePay.pay(address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID)]);"
         );
 
-        assertEq(result.quarkOperations[0].scriptSources.length, 2);
+        assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(CometRepayAndWithdrawMultipleAssets).creationCode);
-        assertEq(
-            result.quarkOperations[0].scriptSources[1],
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
-        );
+        assertEq(result.quarkOperations[0].scriptSources[1], type(QuotePay).creationCode);
+        assertEq(result.quarkOperations[0].scriptSources[2], type(Multicall).creationCode);
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
         );
@@ -982,6 +839,7 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         });
 
         QuarkBuilder builder = new QuarkBuilder();
+        // Alice needs to bridge ~10 USDC to chain 8453 to repay max, but will pay the quote for both chains on chain 1
         QuarkBuilder.BuilderResult memory result = builder.cometRepay(
             repayIntent_(
                 8453,
@@ -1000,44 +858,40 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         address cctpBridgeActionsAddress = CodeJarHelper.getCodeAddress(type(CCTPBridgeActions).creationCode);
         address cometRepayAndWithdrawMultipleAssetsAddress =
             CodeJarHelper.getCodeAddress(type(CometRepayAndWithdrawMultipleAssets).creationCode);
-        address paycallAddress = CodeJarHelper.getCodeAddress(
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
-        );
-        address paycallAddressBase = CodeJarHelper.getCodeAddress(
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_8453, USDC_8453))
-        );
+        address multicallAddress = CodeJarHelper.getCodeAddress(type(Multicall).creationCode);
+        address quotePayAddress = CodeJarHelper.getCodeAddress(type(QuotePay).creationCode);
 
         // Check the quark operations
         // first operation
         assertEq(result.quarkOperations.length, 2, "two operations");
         assertEq(
             result.quarkOperations[0].scriptAddress,
-            paycallAddress,
-            "script address is correct given the code jar address on base"
+            multicallAddress,
+            "script address[0] has been wrapped with multicall address"
         );
+        address[] memory callContracts = new address[](2);
+        callContracts[0] = cctpBridgeActionsAddress;
+        callContracts[1] = quotePayAddress;
+        bytes[] memory callDatas = new bytes[](2);
+        callDatas[0] = abi.encodeWithSelector(
+            CCTPBridgeActions.bridgeUSDC.selector,
+            address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
+            10.01e6, // 10e6 repaid + .1% buffer
+            6,
+            bytes32(uint256(uint160(0xa11ce))),
+            usdc_(1)
+        );
+        // Covers the quote for both chains
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.2e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                cctpBridgeActionsAddress,
-                abi.encodeWithSelector(
-                    CCTPBridgeActions.bridgeUSDC.selector,
-                    address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
-                    10.11e6, // 10e6 repaid + .1% buffer + 0.1e6 max cost on Base
-                    6,
-                    bytes32(uint256(uint160(0xa11ce))),
-                    usdc_(1)
-                ),
-                0.1e6
-            ),
-            "calldata is Paycall.run(CCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 10.11e6, 6, 0xa11ce, USDC_1)), 0.1e6);"
+            abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
+            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 10.01e6, 6, 0xa11ce, USDC_1), QuotePay.pay(address(0xa11ce), USDC_1, 0.2e6, QUOTE_ID)]);"
         );
-        assertEq(result.quarkOperations[0].scriptSources.length, 2);
+        assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(CCTPBridgeActions).creationCode);
-        assertEq(
-            result.quarkOperations[0].scriptSources[1],
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
-        );
+        assertEq(result.quarkOperations[0].scriptSources[1], type(QuotePay).creationCode);
+        assertEq(result.quarkOperations[0].scriptSources[2], type(Multicall).creationCode);
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
         );
@@ -1047,32 +901,23 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         // second operation
         assertEq(
             result.quarkOperations[1].scriptAddress,
-            paycallAddressBase,
-            "script address[1] has been wrapped with paycall address"
+            cometRepayAndWithdrawMultipleAssetsAddress,
+            "script address is repay action"
         );
         assertEq(
             result.quarkOperations[1].scriptCalldata,
             abi.encodeWithSelector(
-                Paycall.run.selector,
-                cometRepayAndWithdrawMultipleAssetsAddress,
-                abi.encodeWithSelector(
-                    CometRepayAndWithdrawMultipleAssets.run.selector,
-                    cometUsdc_(8453),
-                    collateralTokens,
-                    collateralAmounts,
-                    usdc_(8453),
-                    type(uint256).max
-                ),
-                0.1e6
+                CometRepayAndWithdrawMultipleAssets.run.selector,
+                cometUsdc_(8453),
+                collateralTokens,
+                collateralAmounts,
+                usdc_(8453),
+                type(uint256).max
             ),
-            "calldata is Paycall.run(CometRepayAndWithdrawMultipleAssets.run(cometUsdc_(8453), [], [], USDC_8453, uint256.max), 0.1e6);"
+            "calldata is CometRepayAndWithdrawMultipleAssets.run(cometUsdc_(8453), [], [], USDC_8453, uint256.max);"
         );
-        assertEq(result.quarkOperations[1].scriptSources.length, 2);
+        assertEq(result.quarkOperations[1].scriptSources.length, 1);
         assertEq(result.quarkOperations[1].scriptSources[0], type(CometRepayAndWithdrawMultipleAssets).creationCode);
-        assertEq(
-            result.quarkOperations[1].scriptSources[1],
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_8453, USDC_8453))
-        );
         assertEq(
             result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
         );
@@ -1094,8 +939,8 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
             abi.encode(
                 Actions.BridgeActionContext({
                     assetSymbol: "USDC",
-                    inputAmount: 10.11e6,
-                    outputAmount: 10.11e6,
+                    inputAmount: 10.01e6,
+                    outputAmount: 10.01e6,
                     bridgeType: Actions.BRIDGE_TYPE_CCTP,
                     chainId: 1,
                     destinationChainId: 8453,

--- a/test/builder/QuarkBuilderCometSupply.t.sol
+++ b/test/builder/QuarkBuilderCometSupply.t.sol
@@ -378,11 +378,12 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         callContracts[1] = quotePayAddress;
         bytes[] memory callDatas = new bytes[](2);
         callDatas[0] = abi.encodeWithSelector(CometSupplyActions.supply.selector, COMET, usdc_(1), 1e6);
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.1e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([cometSupplyActionsAddress, quotePayAddress], [CometSupplyActions.supply(COMET, USDC, 1e6), QuotePay.pay(address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([cometSupplyActionsAddress, quotePayAddress], [CometSupplyActions.supply(COMET, USDC, 1e6), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.1e6, QUOTE_ID)]);"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(CometSupplyActions).creationCode);
@@ -758,11 +759,12 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
             usdc_(1)
         );
         // TODO: Should be 0xbob once multi account is supported
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.6e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.6e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 2.4e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1)), QuotePay.pay(address(0xa11ce), USDC_1, 0.6e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 2.4e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1)), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.6e6, QUOTE_ID)]);"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(CCTPBridgeActions).creationCode);
@@ -887,11 +889,12 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
             usdc_(1)
         );
         // TODO: Should be 0xbob once multi account is supported
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.6e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.6e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 2e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1)), QuotePay.pay(address(0xa11ce), USDC_1, 0.6e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 2e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1)), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.6e6, QUOTE_ID)]);"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(CCTPBridgeActions).creationCode);

--- a/test/builder/QuarkBuilderCometSupply.t.sol
+++ b/test/builder/QuarkBuilderCometSupply.t.sol
@@ -61,7 +61,7 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         });
     }
 
-    function testInsufficientFunds() public {
+    function testCometSupplyInsufficientFunds() public {
         QuarkBuilder builder = new QuarkBuilder();
         vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.FundsUnavailable.selector, "USDC", 2e6, 0e6));
         builder.cometSupply(
@@ -71,9 +71,9 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         );
     }
 
-    function testMaxCostTooHigh() public {
+    function testCometSupplyMaxCostTooHigh() public {
         QuarkBuilder builder = new QuarkBuilder();
-        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "usdc"));
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.ImpossibleToConstructQuotePay.selector, "usdc"));
         builder.cometSupply(
             cometSupply_(1, 1e6),
             chainAccountsList_(2e6), // holding 2 USDC in total across 1, 8453
@@ -81,7 +81,7 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         );
     }
 
-    function testFundsUnavailable() public {
+    function testCometSupplyFundsUnavailable() public {
         QuarkBuilder builder = new QuarkBuilder();
         vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.FundsUnavailable.selector, "USDC", 2e6, 0));
         builder.cometSupply(

--- a/test/builder/QuarkBuilderCometWithdraw.t.sol
+++ b/test/builder/QuarkBuilderCometWithdraw.t.sol
@@ -386,7 +386,7 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
 
         QuarkBuilder builder = new QuarkBuilder();
 
-        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "usdc"));
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.ImpossibleToConstructQuotePay.selector, "usdc"));
         builder.cometWithdraw(
             cometWithdraw_(1, cometUsdc_(1), "USDC", type(uint256).max),
             chainAccountsFromChainPortfolios(chainPortfolios),
@@ -401,7 +401,7 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         maxCosts[2] = PaymentInfo.PaymentMaxCost({chainId: 7777, amount: 5e6});
         QuarkBuilder builder = new QuarkBuilder();
 
-        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "usdc"));
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.ImpossibleToConstructQuotePay.selector, "usdc"));
         builder.cometWithdraw(
             cometWithdraw_(1, cometUsdc_(1), "USDC", 1e6),
             chainAccountsList_(0e6),

--- a/test/builder/QuarkBuilderCometWithdraw.t.sol
+++ b/test/builder/QuarkBuilderCometWithdraw.t.sol
@@ -151,11 +151,12 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         callContracts[1] = quotePayAddress;
         bytes[] memory callDatas = new bytes[](2);
         callDatas[0] = abi.encodeWithSelector(CometWithdrawActions.withdraw.selector, cometUsdc_(1), link_(1), 1e18);
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.1e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([cometWithdrawActionsAddress, quotePayAddress], [CometWithdrawActions.withdraw(cometUsdc_(1), LINK_1, 1e18), QuotePay.pay(address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([cometWithdrawActionsAddress, quotePayAddress], [CometWithdrawActions.withdraw(cometUsdc_(1), LINK_1, 1e18), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.1e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -222,11 +223,12 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         callContracts[1] = quotePayAddress;
         bytes[] memory callDatas = new bytes[](2);
         callDatas[0] = abi.encodeWithSelector(CometWithdrawActions.withdraw.selector, cometUsdc_(1), usdc_(1), 1e6);
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.5e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.5e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([cometWithdrawActionsAddress, quotePayAddress], [CometWithdrawActions.withdraw(COMET, USDC_1, 1e6), QuotePay.pay(address(0xa11ce), USDC_1, 0.5e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([cometWithdrawActionsAddress, quotePayAddress], [CometWithdrawActions.withdraw(COMET, USDC_1, 1e6), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.5e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -316,11 +318,12 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         bytes[] memory callDatas = new bytes[](2);
         callDatas[0] =
             abi.encodeWithSelector(CometWithdrawActions.withdraw.selector, cometUsdc_(1), usdc_(1), type(uint256).max);
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.1e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([cometWithdrawActionsAddress, quotePayAddress], [CometWithdrawActions.withdraw(COMET, USDC_1, uint256.max), QuotePay.pay(address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([cometWithdrawActionsAddress, quotePayAddress], [CometWithdrawActions.withdraw(COMET, USDC_1, uint256.max), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.1e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"

--- a/test/builder/QuarkBuilderCometWithdraw.t.sol
+++ b/test/builder/QuarkBuilderCometWithdraw.t.sol
@@ -260,19 +260,6 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testWithdrawNotEnoughFundsToBridge() public {
-        QuarkBuilder builder = new QuarkBuilder();
-        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
-        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 1000e6}); // max cost is 1000 USDC
-        maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 0.1e6});
-        vm.expectRevert(abi.encodeWithSelector(Actions.NotEnoughFundsToBridge.selector, "usdc", 9.98e8, 9.971e8));
-        builder.cometWithdraw(
-            cometWithdraw_(1, cometUsdc_(1), "USDC", 1e6),
-            chainAccountsList_(2e6), // holding 2 USDC in total across 1, 8453
-            paymentUsdc_(maxCosts)
-        );
-    }
-
     function testCometWithdrawWithBridge() public {
         QuarkBuilder builder = new QuarkBuilder();
 
@@ -548,8 +535,7 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
 
         QuarkBuilder builder = new QuarkBuilder();
 
-        vm.expectRevert(abi.encodeWithSelector(Actions.NotEnoughFundsToBridge.selector, "usdc", 99e6, 99e6));
-
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "usdc"));
         builder.cometWithdraw(
             cometWithdraw_(1, cometUsdc_(1), "USDC", type(uint256).max),
             chainAccountsFromChainPortfolios(chainPortfolios),
@@ -558,13 +544,13 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
     }
 
     function testCometWithdrawCostTooHigh() public {
-        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
+        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](3);
         maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 5e6});
         maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 5e6});
+        maxCosts[2] = PaymentInfo.PaymentMaxCost({chainId: 7777, amount: 5e6});
         QuarkBuilder builder = new QuarkBuilder();
 
-        vm.expectRevert(abi.encodeWithSelector(Actions.NotEnoughFundsToBridge.selector, "usdc", 4e6, 4e6));
-
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "usdc"));
         builder.cometWithdraw(
             cometWithdraw_(1, cometUsdc_(1), "USDC", 1e6),
             chainAccountsList_(0e6),

--- a/test/builder/QuarkBuilderCometWithdraw.t.sol
+++ b/test/builder/QuarkBuilderCometWithdraw.t.sol
@@ -11,7 +11,8 @@ import {Actions} from "src/builder/actions/Actions.sol";
 import {CCTPBridgeActions} from "src/BridgeScripts.sol";
 import {CodeJarHelper} from "src/builder/CodeJarHelper.sol";
 import {CometWithdrawActions, TransferActions} from "src/DeFiScripts.sol";
-import {Paycall} from "src/Paycall.sol";
+import {Multicall} from "src/Multicall.sol";
+import {QuotePay} from "src/QuotePay.sol";
 
 contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
     function cometWithdraw_(uint256 chainId, address comet, string memory assetSymbol, uint256 amount)
@@ -122,7 +123,7 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testCometWithdrawWithPaycall() public {
+    function testCometWithdrawWithQuotePay() public {
         QuarkBuilder builder = new QuarkBuilder();
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
         maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.1e6});
@@ -133,7 +134,8 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         );
 
         address cometWithdrawActionsAddress = CodeJarHelper.getCodeAddress(type(CometWithdrawActions).creationCode);
-        address paycallAddress = paycallUsdc_(1);
+        address multicallAddress = CodeJarHelper.getCodeAddress(type(Multicall).creationCode);
+        address quotePayAddress = CodeJarHelper.getCodeAddress(type(QuotePay).creationCode);
 
         assertEq(result.paymentCurrency, "usdc", "usdc currency");
 
@@ -141,18 +143,19 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         assertEq(result.quarkOperations.length, 1, "one operation");
         assertEq(
             result.quarkOperations[0].scriptAddress,
-            paycallAddress,
+            multicallAddress,
             "script address is correct given the code jar address on mainnet"
         );
+        address[] memory callContracts = new address[](2);
+        callContracts[0] = cometWithdrawActionsAddress;
+        callContracts[1] = quotePayAddress;
+        bytes[] memory callDatas = new bytes[](2);
+        callDatas[0] = abi.encodeWithSelector(CometWithdrawActions.withdraw.selector, cometUsdc_(1), link_(1), 1e18);
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                cometWithdrawActionsAddress,
-                abi.encodeWithSelector(CometWithdrawActions.withdraw.selector, cometUsdc_(1), link_(1), 1e18),
-                0.1e6
-            ),
-            "calldata is Paycall.run(CometWithdrawActions.withdraw(cometUsdc_(1), LINK_1, 1e18), 0.1e6);"
+            abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
+            "calldata is Multicall.run([cometWithdrawActionsAddress, quotePayAddress], [CometWithdrawActions.withdraw(cometUsdc_(1), LINK_1, 1e18), QuotePay.pay(address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -202,7 +205,8 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         );
 
         address cometWithdrawActionsAddress = CodeJarHelper.getCodeAddress(type(CometWithdrawActions).creationCode);
-        address paycallAddress = paycallUsdc_(1);
+        address multicallAddress = CodeJarHelper.getCodeAddress(type(Multicall).creationCode);
+        address quotePayAddress = CodeJarHelper.getCodeAddress(type(QuotePay).creationCode);
 
         assertEq(result.paymentCurrency, "usdc", "usdc currency");
 
@@ -210,18 +214,19 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         assertEq(result.quarkOperations.length, 1, "one operation");
         assertEq(
             result.quarkOperations[0].scriptAddress,
-            paycallAddress,
+            multicallAddress,
             "script address is correct given the code jar address on mainnet"
         );
+        address[] memory callContracts = new address[](2);
+        callContracts[0] = cometWithdrawActionsAddress;
+        callContracts[1] = quotePayAddress;
+        bytes[] memory callDatas = new bytes[](2);
+        callDatas[0] = abi.encodeWithSelector(CometWithdrawActions.withdraw.selector, cometUsdc_(1), usdc_(1), 1e6);
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.5e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                cometWithdrawActionsAddress,
-                abi.encodeWithSelector(CometWithdrawActions.withdraw.selector, cometUsdc_(1), usdc_(1), 1e6),
-                0.5e6
-            ),
-            "calldata is Paycall.run(CometWithdrawActions.withdraw(COMET, USDC_1, 1e6), 0.5e6);"
+            abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
+            "calldata is Multicall.run([cometWithdrawActionsAddress, quotePayAddress], [CometWithdrawActions.withdraw(COMET, USDC_1, 1e6), QuotePay.pay(address(0xa11ce), USDC_1, 0.5e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -249,161 +254,6 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
                     comet: cometUsdc_(1),
                     price: USDC_PRICE,
                     token: usdc_(1)
-                })
-            ),
-            "action context encoded from WithdrawActionContext"
-        );
-
-        // TODO: Check the contents of the EIP712 data
-        assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
-        assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");
-        assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
-    }
-
-    function testCometWithdrawWithBridge() public {
-        QuarkBuilder builder = new QuarkBuilder();
-
-        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
-        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.1e6});
-        maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 1e6}); // max cost on base is 1 USDC
-
-        Accounts.ChainAccounts[] memory chainAccountsList = new Accounts.ChainAccounts[](2);
-        chainAccountsList[0] = Accounts.ChainAccounts({
-            chainId: 1,
-            quarkSecrets: quarkSecrets_(address(0xa11ce), ALICE_DEFAULT_SECRET),
-            assetPositionsList: assetPositionsList_(1, address(0xa11ce), 3e6), // 3 USDC on mainnet
-            cometPositions: emptyCometPositions_(),
-            morphoPositions: emptyMorphoPositions_(),
-            morphoVaultPositions: emptyMorphoVaultPositions_()
-        });
-        chainAccountsList[1] = Accounts.ChainAccounts({
-            chainId: 8453,
-            quarkSecrets: quarkSecrets_(address(0xb0b), BOB_DEFAULT_SECRET),
-            assetPositionsList: assetPositionsList_(8453, address(0xb0b), 0), // 0 USDC on base
-            cometPositions: emptyCometPositions_(),
-            morphoPositions: emptyMorphoPositions_(),
-            morphoVaultPositions: emptyMorphoVaultPositions_()
-        });
-
-        QuarkBuilder.BuilderResult memory result = builder.cometWithdraw(
-            // We need to set Bob as the withdrawer because only he has an account on chain 8453
-            cometWithdraw_({
-                chainId: 8453,
-                comet: cometUsdc_(8453),
-                assetSymbol: "LINK",
-                amount: 5e18,
-                withdrawer: address(0xb0b)
-            }),
-            chainAccountsList,
-            paymentUsdc_(maxCosts)
-        );
-
-        address paycallAddress = paycallUsdc_(1);
-        address paycallAddressBase = paycallUsdc_(8453);
-        address cctpBridgeActionsAddress = CodeJarHelper.getCodeAddress(type(CCTPBridgeActions).creationCode);
-
-        assertEq(result.paymentCurrency, "usdc", "usdc currency");
-
-        // Check the quark operations
-        // first operation
-        assertEq(result.quarkOperations.length, 2, "two operations");
-        assertEq(
-            result.quarkOperations[0].scriptAddress,
-            paycallAddress,
-            "script address is correct given the code jar address on base"
-        );
-        assertEq(
-            result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                cctpBridgeActionsAddress,
-                abi.encodeWithSelector(
-                    CCTPBridgeActions.bridgeUSDC.selector,
-                    address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
-                    1e6,
-                    6,
-                    bytes32(uint256(uint160(0xb0b))),
-                    usdc_(1)
-                ),
-                0.1e6
-            ),
-            "calldata is Paycall.run(CCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 1e6, 6, 0xb0b, USDC_1)), 0.1e6);"
-        );
-        assertEq(
-            result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
-        );
-        assertEq(result.quarkOperations[0].nonce, ALICE_DEFAULT_SECRET, "unexpected nonce");
-        assertEq(result.quarkOperations[0].isReplayable, false, "isReplayable is false");
-
-        // second operation
-        assertEq(
-            result.quarkOperations[1].scriptAddress,
-            paycallAddressBase,
-            "script address[1] has been wrapped with paycall address"
-        );
-        assertEq(
-            result.quarkOperations[1].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                CodeJarHelper.getCodeAddress(type(CometWithdrawActions).creationCode),
-                abi.encodeCall(CometWithdrawActions.withdraw, (cometUsdc_(8453), link_(8453), 5e18)),
-                1e6
-            ),
-            "calldata is Paycall.run(CometWithdrawActions.withdraw(COMET, LINK_8453, 5e18), 1e6);"
-        );
-        assertEq(
-            result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
-        );
-        assertEq(result.quarkOperations[1].nonce, BOB_DEFAULT_SECRET, "unexpected nonce");
-        assertEq(result.quarkOperations[1].isReplayable, false, "isReplayable is false");
-
-        // Check the actions
-        assertEq(result.actions.length, 2, "two actions");
-        // first action
-        assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
-        assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
-        assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
-        assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
-        assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
-        assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
-        assertEq(
-            result.actions[0].actionContext,
-            abi.encode(
-                Actions.BridgeActionContext({
-                    assetSymbol: "USDC",
-                    inputAmount: 1e6,
-                    outputAmount: 1e6,
-                    bridgeType: Actions.BRIDGE_TYPE_CCTP,
-                    chainId: 1,
-                    destinationChainId: 8453,
-                    price: USDC_PRICE,
-                    recipient: address(0xb0b),
-                    token: USDC_1
-                })
-            ),
-            "action context encoded from BridgeActionContext"
-        );
-        // second action
-        assertEq(result.actions[1].chainId, 8453, "operation is on chainid 8453");
-        assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
-        assertEq(result.actions[1].actionType, "WITHDRAW", "action type is 'WITHDRAW'");
-        assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
-        assertEq(result.actions[1].paymentMaxCost, 1e6, "payment should have max cost of 1e6");
-        assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
-        assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
-        assertEq(
-            result.actions[1].actionContext,
-            abi.encode(
-                Actions.WithdrawActionContext({
-                    amount: 5e18,
-                    assetSymbol: "LINK",
-                    chainId: 8453,
-                    comet: cometUsdc_(8453),
-                    price: LINK_PRICE,
-                    token: link_(8453)
                 })
             ),
             "action context encoded from WithdrawActionContext"
@@ -447,8 +297,9 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
             paymentUsdc_(maxCosts) // but will pay from withdrawn funds
         );
 
-        address paycallAddress = paycallUsdc_(1);
         address cometWithdrawActionsAddress = CodeJarHelper.getCodeAddress(type(CometWithdrawActions).creationCode);
+        address multicallAddress = CodeJarHelper.getCodeAddress(type(Multicall).creationCode);
+        address quotePayAddress = CodeJarHelper.getCodeAddress(type(QuotePay).creationCode);
 
         assertEq(result.paymentCurrency, "usdc", "usdc currency");
 
@@ -456,20 +307,20 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         assertEq(result.quarkOperations.length, 1, "one operation");
         assertEq(
             result.quarkOperations[0].scriptAddress,
-            paycallAddress,
+            multicallAddress,
             "script address is correct given the code jar address on mainnet"
         );
+        address[] memory callContracts = new address[](2);
+        callContracts[0] = cometWithdrawActionsAddress;
+        callContracts[1] = quotePayAddress;
+        bytes[] memory callDatas = new bytes[](2);
+        callDatas[0] =
+            abi.encodeWithSelector(CometWithdrawActions.withdraw.selector, cometUsdc_(1), usdc_(1), type(uint256).max);
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                cometWithdrawActionsAddress,
-                abi.encodeWithSelector(
-                    CometWithdrawActions.withdraw.selector, cometUsdc_(1), usdc_(1), type(uint256).max
-                ),
-                0.1e6
-            ),
-            "calldata is Paycall.run(CometWithdrawActions.withdraw(COMET, USDC_1, uint256.max), 0.1e6);"
+            abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
+            "calldata is Multicall.run([cometWithdrawActionsAddress, quotePayAddress], [CometWithdrawActions.withdraw(COMET, USDC_1, uint256.max), QuotePay.pay(address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"

--- a/test/builder/QuarkBuilderMorphoBorrow.t.sol
+++ b/test/builder/QuarkBuilderMorphoBorrow.t.sol
@@ -57,7 +57,7 @@ contract QuarkBuilderMorphoBorrowTest is Test, QuarkBuilderTest {
         });
     }
 
-    function testBorrowInvalidMarketParams() public {
+    function testMorphoBorrowInvalidMarketParams() public {
         QuarkBuilder builder = new QuarkBuilder();
         ChainPortfolio[] memory chainPortfolios = new ChainPortfolio[](2);
         chainPortfolios[0] = ChainPortfolio({
@@ -90,7 +90,7 @@ contract QuarkBuilderMorphoBorrowTest is Test, QuarkBuilderTest {
         );
     }
 
-    function testBorrowFundsUnavailable() public {
+    function testMorphoBorrowFundsUnavailable() public {
         QuarkBuilder builder = new QuarkBuilder();
         vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.FundsUnavailable.selector, "WBTC", 1e8, 0));
         builder.morphoBorrow(
@@ -100,7 +100,7 @@ contract QuarkBuilderMorphoBorrowTest is Test, QuarkBuilderTest {
         );
     }
 
-    function testBorrowSuccess() public {
+    function testMorphoBorrowSuccess() public {
         ChainPortfolio[] memory chainPortfolios = new ChainPortfolio[](2);
         chainPortfolios[0] = ChainPortfolio({
             chainId: 1,
@@ -187,7 +187,7 @@ contract QuarkBuilderMorphoBorrowTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testBorrowWithAutoWrapper() public {
+    function testMorphoBorrowWithAutoWrapper() public {
         ChainPortfolio[] memory chainPortfolios = new ChainPortfolio[](2);
         chainPortfolios[0] = ChainPortfolio({
             chainId: 1,
@@ -291,7 +291,7 @@ contract QuarkBuilderMorphoBorrowTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testBorrowWithPaycall() public {
+    function testMorphoBorrowWithPaycall() public {
         ChainPortfolio[] memory chainPortfolios = new ChainPortfolio[](2);
         chainPortfolios[0] = ChainPortfolio({
             chainId: 1,
@@ -397,7 +397,7 @@ contract QuarkBuilderMorphoBorrowTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testBorrowPayFromBorrow() public {
+    function testMorphoBorrowPayFromBorrow() public {
         ChainPortfolio[] memory chainPortfolios = new ChainPortfolio[](2);
         chainPortfolios[0] = ChainPortfolio({
             chainId: 1,
@@ -503,7 +503,7 @@ contract QuarkBuilderMorphoBorrowTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testBorrowWithBridgedPaymentToken() public {
+    function testMorphoBorrowWithBridgedPaymentToken() public {
         ChainPortfolio[] memory chainPortfolios = new ChainPortfolio[](2);
         chainPortfolios[0] = ChainPortfolio({
             chainId: 1,

--- a/test/builder/QuarkBuilderMorphoBorrow.t.sol
+++ b/test/builder/QuarkBuilderMorphoBorrow.t.sol
@@ -345,11 +345,12 @@ contract QuarkBuilderMorphoBorrowTest is Test, QuarkBuilderTest {
             MorphoActions.supplyCollateralAndBorrow,
             (MorphoInfo.getMorphoAddress(1), MorphoInfo.getMarketParams(1, "WBTC", "USDC"), 1e8, 1e6)
         );
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.1e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([morphoActionsAddress, quotePayAddress], [MorphoActions.supplyCollateralAndBorrow(MorphoInfo.getMorphoAddress(1), MorphoInfo.getMarketParams(1, WBTC, USDC), 1e8, 1e6, address(0xa11ce), address(0xa11ce)), QuotePay.pay(address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([morphoActionsAddress, quotePayAddress], [MorphoActions.supplyCollateralAndBorrow(MorphoInfo.getMorphoAddress(1), MorphoInfo.getMarketParams(1, WBTC, USDC), 1e8, 1e6, address(0xa11ce), address(0xa11ce)), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.1e6, QUOTE_ID)]);"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(MorphoActions).creationCode);
@@ -450,11 +451,12 @@ contract QuarkBuilderMorphoBorrowTest is Test, QuarkBuilderTest {
             MorphoActions.supplyCollateralAndBorrow,
             (MorphoInfo.getMorphoAddress(1), MorphoInfo.getMarketParams(1, "WBTC", "USDC"), 1e8, 1e6)
         );
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.1e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([morphoActionsAddress, quotePayAddress], [MorphoActions.supplyCollateralAndBorrow(MorphoInfo.getMorphoAddress(), MorphoInfo.getMarketParams(1, WBTC, USDC), 1e8, 1e6, address(0xa11ce), address(0xa11ce)), QuotePay.pay(address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([morphoActionsAddress, quotePayAddress], [MorphoActions.supplyCollateralAndBorrow(MorphoInfo.getMorphoAddress(), MorphoInfo.getMarketParams(1, WBTC, USDC), 1e8, 1e6, address(0xa11ce), address(0xa11ce)), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.1e6, QUOTE_ID)]);"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(MorphoActions).creationCode);

--- a/test/builder/QuarkBuilderMorphoBorrow.t.sol
+++ b/test/builder/QuarkBuilderMorphoBorrow.t.sol
@@ -518,7 +518,7 @@ contract QuarkBuilderMorphoBorrowTest is Test, QuarkBuilderTest {
             morphoVaultPortfolios: emptyMorphoVaultPortfolios_()
         });
 
-        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "usdc"));
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.ImpossibleToConstructQuotePay.selector, "usdc"));
         builder.morphoBorrow(
             borrowIntent_(1, "WETH", 1e18, "WBTC", 0),
             chainAccountsFromChainPortfolios(chainPortfolios),

--- a/test/builder/QuarkBuilderMorphoClaimRewards.t.sol
+++ b/test/builder/QuarkBuilderMorphoClaimRewards.t.sol
@@ -250,7 +250,7 @@ contract QuarkBuilderMorphoClaimRewardsTest is Test, QuarkBuilderTest {
         maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 100e6});
         maxCosts[2] = PaymentInfo.PaymentMaxCost({chainId: 7777, amount: 100e6});
 
-        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "usdc"));
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.ImpossibleToConstructQuotePay.selector, "usdc"));
         builder.morphoClaimRewards(
             morphoClaimRewardsIntent_(
                 1, fixtureAccounts, fixtureClaimablesLessUSDC, fixtureDistributors, fixtureRewards, fixtureProofs

--- a/test/builder/QuarkBuilderMorphoClaimRewards.t.sol
+++ b/test/builder/QuarkBuilderMorphoClaimRewards.t.sol
@@ -187,11 +187,11 @@ contract QuarkBuilderMorphoClaimRewardsTest is Test, QuarkBuilderTest {
             MorphoRewardsActions.claimAll,
             (fixtureDistributors, fixtureAccounts, fixtureRewards, fixtureClaimables, fixtureProofs)
         );
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 1e6, QUOTE_ID);
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 1e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([morphoRewardsActionsAddress, quotePayAddress], [MorphoRewardsActions.claimAll(fixtureDistributors, fixtureAccounts, fixtureRewards, fixtureClaimables, fixtureProofs), QuotePay.pay(address(0xa11ce), USDC_1, 1e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([morphoRewardsActionsAddress, quotePayAddress], [MorphoRewardsActions.claimAll(fixtureDistributors, fixtureAccounts, fixtureRewards, fixtureClaimables, fixtureProofs), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 1e6, QUOTE_ID)]);"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(MorphoRewardsActions).creationCode);

--- a/test/builder/QuarkBuilderMorphoClaimRewards.t.sol
+++ b/test/builder/QuarkBuilderMorphoClaimRewards.t.sol
@@ -12,11 +12,12 @@ import {CodeJarHelper} from "src/builder/CodeJarHelper.sol";
 import {TransferActions} from "src/DeFiScripts.sol";
 import {MorphoInfo} from "src/builder/MorphoInfo.sol";
 import {MorphoRewardsActions} from "src/MorphoScripts.sol";
+import {Multicall} from "src/Multicall.sol";
 import {List} from "src/builder/List.sol";
-import {Paycall} from "src/Paycall.sol";
 import {QuarkBuilder} from "src/builder/QuarkBuilder.sol";
 import {QuarkBuilderBase} from "src/builder/QuarkBuilderBase.sol";
 import {MorphoActionsBuilder} from "src/builder/actions/MorphoActionsBuilder.sol";
+import {QuotePay} from "src/QuotePay.sol";
 
 contract QuarkBuilderMorphoClaimRewardsTest is Test, QuarkBuilderTest {
     // Fixtures of morpho reward data to pass in
@@ -152,8 +153,11 @@ contract QuarkBuilderMorphoClaimRewardsTest is Test, QuarkBuilderTest {
 
     function testMorphoClaimRewardsPayWithReward() public {
         QuarkBuilder builder = new QuarkBuilder();
-        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
+        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](3);
         maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 1e6});
+        maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 1e6});
+        maxCosts[2] = PaymentInfo.PaymentMaxCost({chainId: 7777, amount: 1e6});
+
         QuarkBuilder.BuilderResult memory result = builder.morphoClaimRewards(
             morphoClaimRewardsIntent_(
                 1, fixtureAccounts, fixtureClaimables, fixtureDistributors, fixtureRewards, fixtureProofs
@@ -162,32 +166,37 @@ contract QuarkBuilderMorphoClaimRewardsTest is Test, QuarkBuilderTest {
             paymentUsdc_(maxCosts)
         );
 
+        address morphoRewardsActionsAddress = CodeJarHelper.getCodeAddress(type(MorphoRewardsActions).creationCode);
+        address multicallAddress = CodeJarHelper.getCodeAddress(type(Multicall).creationCode);
+        address quotePayAddress = CodeJarHelper.getCodeAddress(type(QuotePay).creationCode);
+
         assertEq(result.paymentCurrency, "usdc", "usdc currency");
 
         // Check the quark operations
         assertEq(result.quarkOperations.length, 1, "one operation");
         assertEq(
             result.quarkOperations[0].scriptAddress,
-            paycallUsdc_(1),
+            multicallAddress,
             "script address is correct given the code jar address on mainnet"
         );
+        address[] memory callContracts = new address[](2);
+        callContracts[0] = morphoRewardsActionsAddress;
+        callContracts[1] = quotePayAddress;
+        bytes[] memory callDatas = new bytes[](2);
+        callDatas[0] = abi.encodeCall(
+            MorphoRewardsActions.claimAll,
+            (fixtureDistributors, fixtureAccounts, fixtureRewards, fixtureClaimables, fixtureProofs)
+        );
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 1e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                CodeJarHelper.getCodeAddress(type(MorphoRewardsActions).creationCode),
-                abi.encodeCall(
-                    MorphoRewardsActions.claimAll,
-                    (fixtureDistributors, fixtureAccounts, fixtureRewards, fixtureClaimables, fixtureProofs)
-                ),
-                1e6
-            ),
-            "calldata is Paycall.run(MorphoRewardsActions.claimAll(fixtureDistributors, fixtureAccounts, fixtureRewards, fixtureClaimables, fixtureProofs));"
+            abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
+            "calldata is Multicall.run([morphoRewardsActionsAddress, quotePayAddress], [MorphoRewardsActions.claimAll(fixtureDistributors, fixtureAccounts, fixtureRewards, fixtureClaimables, fixtureProofs), QuotePay.pay(address(0xa11ce), USDC_1, 1e6, QUOTE_ID)]);"
         );
-        assertEq(
-            result.quarkOperations[0].scriptSources[1],
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
-        );
+        assertEq(result.quarkOperations[0].scriptSources.length, 3);
+        assertEq(result.quarkOperations[0].scriptSources[0], type(MorphoRewardsActions).creationCode);
+        assertEq(result.quarkOperations[0].scriptSources[1], type(QuotePay).creationCode);
+        assertEq(result.quarkOperations[0].scriptSources[2], type(Multicall).creationCode);
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
         );
@@ -234,12 +243,14 @@ contract QuarkBuilderMorphoClaimRewardsTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testMorphoClaimRewardsWithNotEnoughRewardToCoverCost() public {
+    function testMorphoClaimRewardsMaxCostTooHigh() public {
         QuarkBuilder builder = new QuarkBuilder();
-        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
-        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 5e6});
-        maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 5e6});
-        vm.expectRevert(abi.encodeWithSelector(Actions.NotEnoughFundsToBridge.selector, "usdc", 3e6, 3e6));
+        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](3);
+        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 100e6});
+        maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 100e6});
+        maxCosts[2] = PaymentInfo.PaymentMaxCost({chainId: 7777, amount: 100e6});
+
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "usdc"));
         builder.morphoClaimRewards(
             morphoClaimRewardsIntent_(
                 1, fixtureAccounts, fixtureClaimablesLessUSDC, fixtureDistributors, fixtureRewards, fixtureProofs

--- a/test/builder/QuarkBuilderMorphoRepay.t.sol
+++ b/test/builder/QuarkBuilderMorphoRepay.t.sol
@@ -362,11 +362,12 @@ contract QuarkBuilderMorphoRepayTest is Test, QuarkBuilderTest {
             MorphoActions.repayAndWithdrawCollateral,
             (MorphoInfo.getMorphoAddress(1), MorphoInfo.getMarketParams(1, "WBTC", "USDC"), 1e6, 0e8)
         );
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.1e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([morphoActionsAddress, quotePayAddress], [MorphoActions.repayAndWithdrawCollateral(MorphoInfo.getMorphoAddress(1), MorphoInfo.getMarketParams(1, WBTC, USDC), 1e6, 0), QuotePay.pay(address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([morphoActionsAddress, quotePayAddress], [MorphoActions.repayAndWithdrawCollateral(MorphoInfo.getMorphoAddress(1), MorphoInfo.getMarketParams(1, WBTC, USDC), 1e6, 0), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.1e6, QUOTE_ID)]);"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(MorphoActions).creationCode);
@@ -496,11 +497,11 @@ contract QuarkBuilderMorphoRepayTest is Test, QuarkBuilderTest {
     //             bytes32(uint256(uint160(0xb0b))),
     //             usdc_(1)
     //         );
-    //         callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.3e6, QUOTE_ID);
+    //         callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.3e6, QUOTE_ID);
     //         assertEq(
     //             result.quarkOperations[0].scriptCalldata,
     //             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-    //             "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 2e6, 6, 0xb0b, USDC_1)), QuotePay.pay(address(0xa11ce), USDC_1, 0.3e6, QUOTE_ID)]);"
+    //             "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 2e6, 6, 0xb0b, USDC_1)), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.3e6, QUOTE_ID)]);"
     //         );
     //     }
     //     assertEq(result.quarkOperations[0].scriptSources.length, 3);
@@ -655,11 +656,11 @@ contract QuarkBuilderMorphoRepayTest is Test, QuarkBuilderTest {
     //             MorphoActions.repayAndWithdrawCollateral,
     //             (MorphoInfo.getMorphoAddress(1), MorphoInfo.getMarketParams(1, "WBTC", "USDC"), type(uint256).max, 0)
     //         );
-    //         callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID);
+    //         callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.1e6, QUOTE_ID);
     //         assertEq(
     //             result.quarkOperations[0].scriptCalldata,
     //             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-    //             "calldata is Multicall.run([morphoActionsAddress, quotePayAddress], [MorphoActions.repayAndWithdrawCollateral(MorphoInfo.getMorphoAddress(1), MorphoInfo.getMarketParams(1, WBTC, USDC), type(uint256).max, 0), QuotePay.pay(address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID)]);"
+    //             "calldata is Multicall.run([morphoActionsAddress, quotePayAddress], [MorphoActions.repayAndWithdrawCollateral(MorphoInfo.getMorphoAddress(1), MorphoInfo.getMarketParams(1, WBTC, USDC), type(uint256).max, 0), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.1e6, QUOTE_ID)]);"
     //         );
     //     }
     //     assertEq(result.quarkOperations[0].scriptSources.length, 3);
@@ -786,11 +787,11 @@ contract QuarkBuilderMorphoRepayTest is Test, QuarkBuilderTest {
     //             bytes32(uint256(uint160(0xb0b))),
     //             usdc_(1)
     //         );
-    //         callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.2e6, QUOTE_ID);
+    //         callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.2e6, QUOTE_ID);
     //         assertEq(
     //             result.quarkOperations[0].scriptCalldata,
     //             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-    //             "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 10.01e6, 6, 0xb0b, USDC_1)), QuotePay.pay(address(0xa11ce), USDC_1, 0.2e6, QUOTE_ID)]);"
+    //             "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 10.01e6, 6, 0xb0b, USDC_1)), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.2e6, QUOTE_ID)]);"
     //         );
     //     }
     //     assertEq(result.quarkOperations[0].scriptSources.length, 3);

--- a/test/builder/QuarkBuilderMorphoRepay.t.sol
+++ b/test/builder/QuarkBuilderMorphoRepay.t.sol
@@ -424,7 +424,7 @@ contract QuarkBuilderMorphoRepayTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testCometRepayWithBridge() public {
+    function testMorphoRepayWithBridge() public {
         QuarkBuilder builder = new QuarkBuilder();
 
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
@@ -604,7 +604,7 @@ contract QuarkBuilderMorphoRepayTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testCometRepayMax() public {
+    function testMorphoRepayMax() public {
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
         maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.1e6});
 
@@ -723,7 +723,7 @@ contract QuarkBuilderMorphoRepayTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testCometRepayMaxWithBridge() public {
+    function testMorphoRepayMaxWithBridge() public {
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
         maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.1e6});
         maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 0.1e6});

--- a/test/builder/QuarkBuilderMorphoRepay.t.sol
+++ b/test/builder/QuarkBuilderMorphoRepay.t.sol
@@ -87,7 +87,7 @@ contract QuarkBuilderMorphoRepayTest is Test, QuarkBuilderTest {
             morphoVaultPortfolios: emptyMorphoVaultPortfolios_()
         });
 
-        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "usdc"));
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.ImpossibleToConstructQuotePay.selector, "usdc"));
         builder.morphoRepay(
             repayIntent_(8453, "WETH", 1e18, "cbETH", 1e18),
             chainAccountsFromChainPortfolios(chainPortfolios),

--- a/test/builder/QuarkBuilderMorphoVaultSupply.t.sol
+++ b/test/builder/QuarkBuilderMorphoVaultSupply.t.sol
@@ -43,7 +43,7 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
         });
     }
 
-    function testInsufficientFunds() public {
+    function testMorphoSupplyInsufficientFunds() public {
         QuarkBuilder builder = new QuarkBuilder();
         vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.FundsUnavailable.selector, "USDC", 2e6, 0e6));
         builder.morphoVaultSupply(
@@ -60,9 +60,9 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
         );
     }
 
-    function testMaxCostTooHigh() public {
+    function testMorphoSupplyMaxCostTooHigh() public {
         QuarkBuilder builder = new QuarkBuilder();
-        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "usdc"));
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.ImpossibleToConstructQuotePay.selector, "usdc"));
         builder.morphoVaultSupply(
             MorphoVaultActionsBuilder.MorphoVaultSupplyIntent({
                 amount: 1e6,
@@ -77,7 +77,7 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
         );
     }
 
-    function testFundsUnavailable() public {
+    function testMorphoSupplyFundsUnavailable() public {
         QuarkBuilder builder = new QuarkBuilder();
         Accounts.ChainAccounts[] memory chainAccountsList = new Accounts.ChainAccounts[](3);
         chainAccountsList[0] = Accounts.ChainAccounts({

--- a/test/builder/QuarkBuilderMorphoVaultSupply.t.sol
+++ b/test/builder/QuarkBuilderMorphoVaultSupply.t.sol
@@ -393,11 +393,12 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
         callDatas[0] = abi.encodeWithSelector(
             MorphoVaultActions.deposit.selector, MorphoInfo.getMorphoVaultAddress(1, "USDC"), usdc_(1), 1e6
         );
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.1e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([morphoVaultActionsAddress, quotePayAddress], [MorphoVaultActions.deposit(MorphoInfo.getMorphoVaultAddress(1, USDC), usdc_(1), 1e6), QuotePay.pay(address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([morphoVaultActionsAddress, quotePayAddress], [MorphoVaultActions.deposit(MorphoInfo.getMorphoVaultAddress(1, USDC), usdc_(1), 1e6), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.1e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -708,11 +709,12 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
             bytes32(uint256(uint160(0xb0b))),
             usdc_(1)
         );
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.6e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.6e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 2.4e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1))), QuotePay.pay(address(0xa11ce), USDC_1, 0.6e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 2.4e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1))), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.6e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -833,11 +835,12 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
             bytes32(uint256(uint160(0xb0b))),
             usdc_(1)
         );
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.6e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.6e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 2e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1))), QuotePay.pay(address(0xa11ce), USDC_1, 0.6e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 2e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1))), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.6e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"

--- a/test/builder/QuarkBuilderMorphoVaultSupply.t.sol
+++ b/test/builder/QuarkBuilderMorphoVaultSupply.t.sol
@@ -63,8 +63,7 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
 
     function testMaxCostTooHigh() public {
         QuarkBuilder builder = new QuarkBuilder();
-        // Max cost is too high, so total available funds is 0
-        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.FundsUnavailable.selector, "USDC", 1e6, 0e6));
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "usdc"));
         builder.morphoVaultSupply(
             MorphoVaultActionsBuilder.MorphoVaultSupplyIntent({
                 amount: 1e6,

--- a/test/builder/QuarkBuilderMorphoVaultWithdraw.t.sol
+++ b/test/builder/QuarkBuilderMorphoVaultWithdraw.t.sol
@@ -135,11 +135,12 @@ contract QuarkBuilderMorphoVaultWithdrawTest is Test, QuarkBuilderTest {
         callDatas[0] = abi.encodeWithSelector(
             MorphoVaultActions.withdraw.selector, MorphoInfo.getMorphoVaultAddress(1, "USDC"), 2e6
         );
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.1e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([morphoVaultActionsAddress, quotePayAddress], [MorphoVaultActions.withdraw(MorphoInfo.getMorphoVaultAddress(1, USDC), QuotePay.pay(address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([morphoVaultActionsAddress, quotePayAddress], [MorphoVaultActions.withdraw(MorphoInfo.getMorphoVaultAddress(1, USDC), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.1e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -206,11 +207,12 @@ contract QuarkBuilderMorphoVaultWithdrawTest is Test, QuarkBuilderTest {
         callDatas[0] = abi.encodeWithSelector(
             MorphoVaultActions.withdraw.selector, MorphoInfo.getMorphoVaultAddress(1, "USDC"), 2e6
         );
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.5e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.5e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([morphoVaultActionsAddress, quotePayAddress], [MorphoVaultWithdrawActions.withdraw(MorphoInfo.getMorphoVaultAddress(1, USDC), 2e6), QuotePay.pay(address(0xa11ce), USDC_1, 0.5e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([morphoVaultActionsAddress, quotePayAddress], [MorphoVaultWithdrawActions.withdraw(MorphoInfo.getMorphoVaultAddress(1, USDC), 2e6), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.5e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -299,11 +301,12 @@ contract QuarkBuilderMorphoVaultWithdrawTest is Test, QuarkBuilderTest {
         callDatas[0] = abi.encodeWithSelector(
             MorphoVaultActions.withdraw.selector, MorphoInfo.getMorphoVaultAddress(1, "USDC"), type(uint256).max
         );
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.1e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([morphoVaultActionsAddress, quotePayAddress], [MorphoVaultActions.redeemAll(MorphoInfo.getMorphoVaultAddress(1, USDC)), QuotePay.pay(address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([morphoVaultActionsAddress, quotePayAddress], [MorphoVaultActions.redeemAll(MorphoInfo.getMorphoVaultAddress(1, USDC)), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.1e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"

--- a/test/builder/QuarkBuilderMorphoVaultWithdraw.t.sol
+++ b/test/builder/QuarkBuilderMorphoVaultWithdraw.t.sol
@@ -367,7 +367,7 @@ contract QuarkBuilderMorphoVaultWithdrawTest is Test, QuarkBuilderTest {
 
         QuarkBuilder builder = new QuarkBuilder();
 
-        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "usdc"));
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.ImpossibleToConstructQuotePay.selector, "usdc"));
         builder.morphoVaultWithdraw(
             morphoWithdrawIntent_(1, type(uint256).max, "USDC"),
             chainAccountsFromChainPortfolios(chainPortfolios),

--- a/test/builder/QuarkBuilderMorphoVaultWithdraw.t.sol
+++ b/test/builder/QuarkBuilderMorphoVaultWithdraw.t.sol
@@ -12,9 +12,10 @@ import {CodeJarHelper} from "src/builder/CodeJarHelper.sol";
 import {CometWithdrawActions, TransferActions} from "src/DeFiScripts.sol";
 import {MorphoInfo} from "src/builder/MorphoInfo.sol";
 import {MorphoVaultActions} from "src/MorphoScripts.sol";
-import {Paycall} from "src/Paycall.sol";
 import {QuarkBuilder} from "src/builder/QuarkBuilder.sol";
 import {QuarkBuilderBase} from "src/builder/QuarkBuilderBase.sol";
+import {Multicall} from "src/Multicall.sol";
+import {QuotePay} from "src/QuotePay.sol";
 
 contract QuarkBuilderMorphoVaultWithdrawTest is Test, QuarkBuilderTest {
     function morphoWithdrawIntent_(uint256 chainId, uint256 amount, string memory assetSymbol)
@@ -106,7 +107,7 @@ contract QuarkBuilderMorphoVaultWithdrawTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testMorphoVaultWithdrawWithPaycall() public {
+    function testMorphoVaultWithdrawWithQuotePay() public {
         QuarkBuilder builder = new QuarkBuilder();
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
         maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.1e6});
@@ -115,7 +116,8 @@ contract QuarkBuilderMorphoVaultWithdrawTest is Test, QuarkBuilderTest {
         );
 
         address morphoVaultActionsAddress = CodeJarHelper.getCodeAddress(type(MorphoVaultActions).creationCode);
-        address paycallAddress = paycallUsdc_(1);
+        address multicallAddress = CodeJarHelper.getCodeAddress(type(Multicall).creationCode);
+        address quotePayAddress = CodeJarHelper.getCodeAddress(type(QuotePay).creationCode);
 
         assertEq(result.paymentCurrency, "usdc", "usdc currency");
 
@@ -123,20 +125,21 @@ contract QuarkBuilderMorphoVaultWithdrawTest is Test, QuarkBuilderTest {
         assertEq(result.quarkOperations.length, 1, "one operation");
         assertEq(
             result.quarkOperations[0].scriptAddress,
-            paycallAddress,
+            multicallAddress,
             "script address is correct given the code jar address on mainnet"
         );
+        address[] memory callContracts = new address[](2);
+        callContracts[0] = morphoVaultActionsAddress;
+        callContracts[1] = quotePayAddress;
+        bytes[] memory callDatas = new bytes[](2);
+        callDatas[0] = abi.encodeWithSelector(
+            MorphoVaultActions.withdraw.selector, MorphoInfo.getMorphoVaultAddress(1, "USDC"), 2e6
+        );
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                morphoVaultActionsAddress,
-                abi.encodeWithSelector(
-                    MorphoVaultActions.withdraw.selector, MorphoInfo.getMorphoVaultAddress(1, "USDC"), 2e6
-                ),
-                0.1e6
-            ),
-            "calldata is Paycall.run(MorphoVaultActions.withdraw(MorphoInfo.getMorphoVaultAddress(1, USDC), 0.1e6);"
+            abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
+            "calldata is Multicall.run([morphoVaultActionsAddress, quotePayAddress], [MorphoVaultActions.withdraw(MorphoInfo.getMorphoVaultAddress(1, USDC), QuotePay.pay(address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -184,7 +187,8 @@ contract QuarkBuilderMorphoVaultWithdrawTest is Test, QuarkBuilderTest {
         );
 
         address morphoVaultActionsAddress = CodeJarHelper.getCodeAddress(type(MorphoVaultActions).creationCode);
-        address paycallAddress = paycallUsdc_(1);
+        address multicallAddress = CodeJarHelper.getCodeAddress(type(Multicall).creationCode);
+        address quotePayAddress = CodeJarHelper.getCodeAddress(type(QuotePay).creationCode);
 
         assertEq(result.paymentCurrency, "usdc", "usdc currency");
 
@@ -192,20 +196,21 @@ contract QuarkBuilderMorphoVaultWithdrawTest is Test, QuarkBuilderTest {
         assertEq(result.quarkOperations.length, 1, "one operation");
         assertEq(
             result.quarkOperations[0].scriptAddress,
-            paycallAddress,
+            multicallAddress,
             "script address is correct given the code jar address on mainnet"
         );
+        address[] memory callContracts = new address[](2);
+        callContracts[0] = morphoVaultActionsAddress;
+        callContracts[1] = quotePayAddress;
+        bytes[] memory callDatas = new bytes[](2);
+        callDatas[0] = abi.encodeWithSelector(
+            MorphoVaultActions.withdraw.selector, MorphoInfo.getMorphoVaultAddress(1, "USDC"), 2e6
+        );
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.5e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                morphoVaultActionsAddress,
-                abi.encodeWithSelector(
-                    MorphoVaultActions.withdraw.selector, MorphoInfo.getMorphoVaultAddress(1, "USDC"), 2e6
-                ),
-                0.5e6
-            ),
-            "calldata is Paycall.run(MorphoVaultWithdrawActions.withdraw(MorphoInfo.getMorphoVaultAddress(1, USDC), 2e6), 0.5e6);"
+            abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
+            "calldata is Multicall.run([morphoVaultActionsAddress, quotePayAddress], [MorphoVaultWithdrawActions.withdraw(MorphoInfo.getMorphoVaultAddress(1, USDC), 2e6), QuotePay.pay(address(0xa11ce), USDC_1, 0.5e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -233,167 +238,6 @@ contract QuarkBuilderMorphoVaultWithdrawTest is Test, QuarkBuilderTest {
                     morphoVault: MorphoInfo.getMorphoVaultAddress(1, "USDC"),
                     price: USDC_PRICE,
                     token: USDC_1
-                })
-            ),
-            "action context encoded from WithdrawActionContext"
-        );
-
-        // TODO: Check the contents of the EIP712 data
-        assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
-        assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");
-        assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
-    }
-
-    function testMorphoVaultWithdrawNotEnoughFundsToBridge() public {
-        QuarkBuilder builder = new QuarkBuilder();
-        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
-        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 1000e6}); // max cost is 1000 USDC
-        maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 0.1e6});
-        vm.expectRevert(abi.encodeWithSelector(Actions.NotEnoughFundsToBridge.selector, "usdc", 998e6, 997.1e6));
-        builder.morphoVaultWithdraw(
-            morphoWithdrawIntent_(1, 1e6, "USDC"),
-            chainAccountsList_(2e6), // holding 2 USDC in total across 1, 8453
-            paymentUsdc_(maxCosts)
-        );
-    }
-
-    function testMorphoVaultWithdrawWithBridge() public {
-        QuarkBuilder builder = new QuarkBuilder();
-
-        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
-        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 0.1e6});
-        maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 1e6}); // max cost on base is 1 USDC
-
-        Accounts.ChainAccounts[] memory chainAccountsList = new Accounts.ChainAccounts[](2);
-        chainAccountsList[0] = Accounts.ChainAccounts({
-            chainId: 1,
-            quarkSecrets: quarkSecrets_(address(0xa11ce), ALICE_DEFAULT_SECRET),
-            assetPositionsList: assetPositionsList_(1, address(0xa11ce), 3e6), // 3 USDC on mainnet
-            cometPositions: emptyCometPositions_(),
-            morphoPositions: emptyMorphoPositions_(),
-            morphoVaultPositions: emptyMorphoVaultPositions_()
-        });
-        chainAccountsList[1] = Accounts.ChainAccounts({
-            chainId: 8453,
-            quarkSecrets: quarkSecrets_(address(0xb0b), BOB_DEFAULT_SECRET),
-            assetPositionsList: assetPositionsList_(8453, address(0xb0b), 0), // 0 USDC on base
-            cometPositions: emptyCometPositions_(),
-            morphoPositions: emptyMorphoPositions_(),
-            morphoVaultPositions: emptyMorphoVaultPositions_()
-        });
-
-        QuarkBuilder.BuilderResult memory result = builder.morphoVaultWithdraw(
-            morphoWithdrawIntent_({chainId: 8453, amount: 1e18, assetSymbol: "WETH", withdrawer: address(0xb0b)}),
-            chainAccountsList,
-            paymentUsdc_(maxCosts)
-        );
-
-        address paycallAddress = paycallUsdc_(1);
-        address paycallAddressBase = paycallUsdc_(8453);
-        address cctpBridgeActionsAddress = CodeJarHelper.getCodeAddress(type(CCTPBridgeActions).creationCode);
-
-        assertEq(result.paymentCurrency, "usdc", "usdc currency");
-
-        // Check the quark operations
-        // first operation
-        assertEq(result.quarkOperations.length, 2, "two operations");
-        assertEq(
-            result.quarkOperations[0].scriptAddress,
-            paycallAddress,
-            "script address is correct given the code jar address on base"
-        );
-        assertEq(
-            result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                cctpBridgeActionsAddress,
-                abi.encodeWithSelector(
-                    CCTPBridgeActions.bridgeUSDC.selector,
-                    address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
-                    1e6,
-                    6,
-                    bytes32(uint256(uint160(0xb0b))),
-                    usdc_(1)
-                ),
-                0.1e6
-            ),
-            "calldata is Paycall.run(CCTPBridgeActions.bridgeUSDC(0xBd3fa81B58Ba92a82136038B25aDec7066af3155, 1e6, 6, 0xb0b, USDC_1)), 0.1e6);"
-        );
-        assertEq(
-            result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
-        );
-        assertEq(result.quarkOperations[0].nonce, ALICE_DEFAULT_SECRET, "unexpected nonce");
-        assertEq(result.quarkOperations[0].isReplayable, false, "isReplayable is false");
-
-        // second operation
-        assertEq(
-            result.quarkOperations[1].scriptAddress,
-            paycallAddressBase,
-            "script address[1] has been wrapped with paycall address"
-        );
-        assertEq(
-            result.quarkOperations[1].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                CodeJarHelper.getCodeAddress(type(MorphoVaultActions).creationCode),
-                abi.encodeCall(MorphoVaultActions.withdraw, (MorphoInfo.getMorphoVaultAddress(8453, "WETH"), 1e18)),
-                1e6
-            ),
-            "calldata is Paycall.run(MorphoVaultActions.withdraw(MorphoInfo.getMorphoVaultAddress(8453, WETH), 1e18);"
-        );
-        assertEq(
-            result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
-        );
-        assertEq(result.quarkOperations[1].nonce, BOB_DEFAULT_SECRET, "unexpected nonce");
-        assertEq(result.quarkOperations[1].isReplayable, false, "isReplayable is false");
-
-        // Check the actions
-        assertEq(result.actions.length, 2, "two actions");
-        // first action
-        assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
-        assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
-        assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
-        assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
-        assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
-        assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
-        assertEq(
-            result.actions[0].actionContext,
-            abi.encode(
-                Actions.BridgeActionContext({
-                    assetSymbol: "USDC",
-                    inputAmount: 1e6,
-                    outputAmount: 1e6,
-                    bridgeType: Actions.BRIDGE_TYPE_CCTP,
-                    chainId: 1,
-                    destinationChainId: 8453,
-                    price: USDC_PRICE,
-                    recipient: address(0xb0b),
-                    token: USDC_1
-                })
-            ),
-            "action context encoded from BridgeActionContext"
-        );
-        // second action
-        assertEq(result.actions[1].chainId, 8453, "operation is on chainid 8453");
-        assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
-        assertEq(result.actions[1].actionType, "MORPHO_VAULT_WITHDRAW", "action type is 'MORPHO_VAULT_WITHDRAW'");
-        assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
-        assertEq(result.actions[1].paymentMaxCost, 1e6, "payment should have max cost of 1e6");
-        assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
-        assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
-        assertEq(
-            result.actions[1].actionContext,
-            abi.encode(
-                Actions.MorphoVaultWithdrawActionContext({
-                    amount: 1e18,
-                    assetSymbol: "WETH",
-                    chainId: 8453,
-                    morphoVault: MorphoInfo.getMorphoVaultAddress(8453, "WETH"),
-                    price: WETH_PRICE,
-                    token: weth_(8453)
                 })
             ),
             "action context encoded from WithdrawActionContext"
@@ -435,8 +279,9 @@ contract QuarkBuilderMorphoVaultWithdrawTest is Test, QuarkBuilderTest {
             paymentUsdc_(maxCosts) // but will pay from withdrawn funds
         );
 
-        address paycallAddress = paycallUsdc_(1);
         address morphoVaultActionsAddress = CodeJarHelper.getCodeAddress(type(MorphoVaultActions).creationCode);
+        address multicallAddress = CodeJarHelper.getCodeAddress(type(Multicall).creationCode);
+        address quotePayAddress = CodeJarHelper.getCodeAddress(type(QuotePay).creationCode);
 
         assertEq(result.paymentCurrency, "usdc", "usdc currency");
 
@@ -444,20 +289,21 @@ contract QuarkBuilderMorphoVaultWithdrawTest is Test, QuarkBuilderTest {
         assertEq(result.quarkOperations.length, 1, "one operation");
         assertEq(
             result.quarkOperations[0].scriptAddress,
-            paycallAddress,
+            multicallAddress,
             "script address is correct given the code jar address on mainnet"
         );
+        address[] memory callContracts = new address[](2);
+        callContracts[0] = morphoVaultActionsAddress;
+        callContracts[1] = quotePayAddress;
+        bytes[] memory callDatas = new bytes[](2);
+        callDatas[0] = abi.encodeWithSelector(
+            MorphoVaultActions.withdraw.selector, MorphoInfo.getMorphoVaultAddress(1, "USDC"), type(uint256).max
+        );
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                morphoVaultActionsAddress,
-                abi.encodeWithSelector(
-                    MorphoVaultActions.withdraw.selector, MorphoInfo.getMorphoVaultAddress(1, "USDC"), type(uint256).max
-                ),
-                0.1e6
-            ),
-            "calldata is Paycall.run(MorphoVaultActions.redeemAll(MorphoInfo.getMorphoVaultAddress(1, USDC)), 0.1e6);"
+            abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
+            "calldata is Multicall.run([morphoVaultActionsAddress, quotePayAddress], [MorphoVaultActions.redeemAll(MorphoInfo.getMorphoVaultAddress(1, USDC)), QuotePay.pay(address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -521,8 +367,7 @@ contract QuarkBuilderMorphoVaultWithdrawTest is Test, QuarkBuilderTest {
 
         QuarkBuilder builder = new QuarkBuilder();
 
-        vm.expectRevert(abi.encodeWithSelector(Actions.NotEnoughFundsToBridge.selector, "usdc", 95e6, 95e6));
-
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "usdc"));
         builder.morphoVaultWithdraw(
             morphoWithdrawIntent_(1, type(uint256).max, "USDC"),
             chainAccountsFromChainPortfolios(chainPortfolios),

--- a/test/builder/QuarkBuilderRecurringSwap.t.sol
+++ b/test/builder/QuarkBuilderRecurringSwap.t.sol
@@ -366,7 +366,6 @@ contract QuarkBuilderRecurringSwapTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    // TODO: What to do here? Recurring should still use paycall
     function testRecurringSwapWithPaycallSucceeds() public {
         QuarkBuilder builder = new QuarkBuilder();
         SwapActionsBuilder.RecurringSwapIntent memory buyWethIntent = buyWeth_({

--- a/test/builder/QuarkBuilderRecurringSwap.t.sol
+++ b/test/builder/QuarkBuilderRecurringSwap.t.sol
@@ -128,7 +128,7 @@ contract QuarkBuilderRecurringSwapTest is Test, QuarkBuilderTest {
 
     function testRecurringSwapMaxCostTooHigh() public {
         QuarkBuilder builder = new QuarkBuilder();
-        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "usdc"));
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructPaycall.selector, "usdc", 1_000e6));
         builder.recurringSwap(
             buyWeth_({
                 chainId: 1,

--- a/test/builder/QuarkBuilderRecurringSwap.t.sol
+++ b/test/builder/QuarkBuilderRecurringSwap.t.sol
@@ -128,8 +128,7 @@ contract QuarkBuilderRecurringSwapTest is Test, QuarkBuilderTest {
 
     function testMaxCostTooHigh() public {
         QuarkBuilder builder = new QuarkBuilder();
-        // Max cost is too high, so total available funds is 0
-        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.FundsUnavailable.selector, "USDC", 30e6, 0e6));
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "usdc"));
         builder.recurringSwap(
             buyWeth_({
                 chainId: 1,
@@ -167,13 +166,13 @@ contract QuarkBuilderRecurringSwapTest is Test, QuarkBuilderTest {
 
     function testFundsUnavailableErrorGivesSuggestionForAvailableFunds() public {
         QuarkBuilder builder = new QuarkBuilder();
-        // The 27e6 is the suggested amount (total available funds) to swap
-        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.FundsUnavailable.selector, "USDC", 30e6, 27e6));
+        // The 30e6 is the suggested amount (total available funds) to swap
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.FundsUnavailable.selector, "USDC", 35e6, 30e6));
         builder.recurringSwap(
             buyWeth_({
                 chainId: 1,
                 sellToken: usdc_(1),
-                sellAmount: 30e6,
+                sellAmount: 35e6,
                 buyAmount: 0.01e18,
                 isExactOut: true,
                 interval: 86_400,

--- a/test/builder/QuarkBuilderRecurringSwap.t.sol
+++ b/test/builder/QuarkBuilderRecurringSwap.t.sol
@@ -126,7 +126,7 @@ contract QuarkBuilderRecurringSwapTest is Test, QuarkBuilderTest {
         );
     }
 
-    function testMaxCostTooHigh() public {
+    function testRecurringSwapMaxCostTooHigh() public {
         QuarkBuilder builder = new QuarkBuilder();
         vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "usdc"));
         builder.recurringSwap(
@@ -366,6 +366,7 @@ contract QuarkBuilderRecurringSwapTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
+    // TODO: What to do here? Recurring should still use paycall
     function testRecurringSwapWithPaycallSucceeds() public {
         QuarkBuilder builder = new QuarkBuilder();
         SwapActionsBuilder.RecurringSwapIntent memory buyWethIntent = buyWeth_({

--- a/test/builder/QuarkBuilderSwap.t.sol
+++ b/test/builder/QuarkBuilderSwap.t.sol
@@ -95,7 +95,7 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         });
     }
 
-    function testInsufficientFunds() public {
+    function testSwapInsufficientFunds() public {
         QuarkBuilder builder = new QuarkBuilder();
         vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.FundsUnavailable.selector, "USDC", 3000e6, 0e6));
         builder.swap(
@@ -105,9 +105,9 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         );
     }
 
-    function testMaxCostTooHigh() public {
+    function testSwapMaxCostTooHigh() public {
         QuarkBuilder builder = new QuarkBuilder();
-        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "usdc"));
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.ImpossibleToConstructQuotePay.selector, "usdc"));
         builder.swap(
             buyWeth_(1, usdc_(1), 30e6, 0.01e18, address(0xa11ce), BLOCK_TIMESTAMP), // swap 30 USDC on chain 1 to 0.01 WETH
             chainAccountsList_(60e6), // holding 60 USDC in total across chains 1, 8453
@@ -115,7 +115,7 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         );
     }
 
-    function testFundsOnUnbridgeableChains() public {
+    function testSwapFundsOnUnbridgeableChains() public {
         QuarkBuilder builder = new QuarkBuilder();
         // FundsUnavailable("USDC", 2e6, 0e6): Requested 2e6, Available 0e6
         vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.FundsUnavailable.selector, "USDC", 30e6, 0e6));
@@ -127,7 +127,7 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         );
     }
 
-    function testFundsUnavailableErrorGivesSuggestionForAvailableFunds() public {
+    function testSwapFundsUnavailableErrorGivesSuggestionForAvailableFunds() public {
         QuarkBuilder builder = new QuarkBuilder();
         // The 30e6 is the suggested amount (total available funds) to swap
         vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.FundsUnavailable.selector, "USDC", 35e6, 30e6));

--- a/test/builder/QuarkBuilderSwap.t.sol
+++ b/test/builder/QuarkBuilderSwap.t.sol
@@ -14,12 +14,10 @@ import {Accounts} from "src/builder/Accounts.sol";
 import {CodeJarHelper} from "src/builder/CodeJarHelper.sol";
 import {QuarkBuilder} from "src/builder/QuarkBuilder.sol";
 import {QuarkBuilderBase} from "src/builder/QuarkBuilderBase.sol";
-import {Paycall} from "src/Paycall.sol";
-import {Quotecall} from "src/Quotecall.sol";
 import {Multicall} from "src/Multicall.sol";
 import {WrapperActions} from "src/WrapperScripts.sol";
-import {PaycallWrapper} from "src/builder/PaycallWrapper.sol";
 import {PaymentInfo} from "src/builder/PaymentInfo.sol";
+import {QuotePay} from "src/QuotePay.sol";
 
 contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
     address constant ZERO_EX_ENTRY_POINT = 0xDef1C0ded9bec7F1a1670819833240f027b25EfF;
@@ -334,7 +332,7 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testLocalSwapWithPaycallSucceeds() public {
+    function testLocalSwapWithQuotePay() public {
         QuarkBuilder builder = new QuarkBuilder();
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](1);
         maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 5e6});
@@ -345,9 +343,8 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         );
 
         address approveAndSwapAddress = CodeJarHelper.getCodeAddress(type(ApproveAndSwap).creationCode);
-        address paycallAddress = CodeJarHelper.getCodeAddress(
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
-        );
+        address multicallAddress = CodeJarHelper.getCodeAddress(type(Multicall).creationCode);
+        address quotePayAddress = CodeJarHelper.getCodeAddress(type(QuotePay).creationCode);
 
         assertEq(result.paymentCurrency, "usdc", "usdc currency");
 
@@ -355,20 +352,21 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         assertEq(result.quarkOperations.length, 1, "one operation");
         assertEq(
             result.quarkOperations[0].scriptAddress,
-            paycallAddress,
-            "script address is correct given the code jar address on mainnet"
+            multicallAddress,
+            "script address[0] has been wrapped with multicall address"
         );
+        address[] memory callContracts = new address[](2);
+        callContracts[0] = approveAndSwapAddress;
+        callContracts[1] = quotePayAddress;
+        bytes[] memory callDatas = new bytes[](2);
+        callDatas[0] = abi.encodeWithSelector(
+            ApproveAndSwap.run.selector, ZERO_EX_ENTRY_POINT, USDC_1, 3000e6, WETH_1, 1e18, ZERO_EX_SWAP_DATA
+        );
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 5e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                approveAndSwapAddress,
-                abi.encodeWithSelector(
-                    ApproveAndSwap.run.selector, ZERO_EX_ENTRY_POINT, USDC_1, 3000e6, WETH_1, 1e18, ZERO_EX_SWAP_DATA
-                ),
-                5e6
-            ),
-            "calldata is Paycall.run(ApproveAndSwap.run(ZERO_EX_ENTRY_POINT, USDC_1, 3500e6, WETH_1, 1e18, ZERO_EX_SWAP_DATA), 5e6);"
+            abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
+            "calldata is Multicall.run([approveAndSwapAddress, quotePayAddress], [ApproveAndSwap.run(ZERO_EX_ENTRY_POINT, USDC_1, 3500e6, WETH_1, 1e18, ZERO_EX_SWAP_DATA), QuotePay.pay(address(0xa11ce), USDC_1, 5e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 3 days, "expiry is current blockTimestamp + 3 days"
@@ -452,9 +450,8 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         );
 
         address approveAndSwapAddress = CodeJarHelper.getCodeAddress(type(ApproveAndSwap).creationCode);
-        address quotecallAddress = CodeJarHelper.getCodeAddress(
-            abi.encodePacked(type(Quotecall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
-        );
+        address multicallAddress = CodeJarHelper.getCodeAddress(type(Multicall).creationCode);
+        address quotePayAddress = CodeJarHelper.getCodeAddress(type(QuotePay).creationCode);
 
         assertEq(result.paymentCurrency, "usdc", "usdc currency");
 
@@ -462,20 +459,21 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         assertEq(result.quarkOperations.length, 1, "one operation");
         assertEq(
             result.quarkOperations[0].scriptAddress,
-            quotecallAddress,
+            multicallAddress,
             "script address is correct given the code jar address on mainnet"
         );
+        address[] memory callContracts = new address[](2);
+        callContracts[0] = approveAndSwapAddress;
+        callContracts[1] = quotePayAddress;
+        bytes[] memory callDatas = new bytes[](2);
+        callDatas[0] = abi.encodeWithSelector(
+            ApproveAndSwap.run.selector, ZERO_EX_ENTRY_POINT, USDC_1, 9000e6, WETH_1, 3e18, ZERO_EX_SWAP_DATA
+        );
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 5e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Quotecall.run.selector,
-                approveAndSwapAddress,
-                abi.encodeWithSelector(
-                    ApproveAndSwap.run.selector, ZERO_EX_ENTRY_POINT, USDC_1, 9000e6, WETH_1, 3e18, ZERO_EX_SWAP_DATA
-                ),
-                5e6
-            ),
-            "calldata is Quotecall.run(ApproveAndSwap.run(ZERO_EX_ENTRY_POINT, USDC_1, 9000e6, WETH_1, 3e18, ZERO_EX_SWAP_DATA), 5e6);"
+            abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
+            "calldata is Multicall.run([approveAndSwapAddress, quotePayAddress], [ApproveAndSwap.run(ZERO_EX_ENTRY_POINT, USDC_1, 9000e6, WETH_1, 3e18, ZERO_EX_SWAP_DATA), QuotePay.pay(address(0xa11ce), USDC_1, 5e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 3 days, "expiry is current blockTimestamp + 3 days"
@@ -671,12 +669,12 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testBridgeSwapWithPaycallSucceeds() public {
+    function testBridgeSwapWithQuotePay() public {
         QuarkBuilder builder = new QuarkBuilder();
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
         maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 5e6});
         maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 1e6});
-        // Note: There are 2000e6 USDC on each chain, so the Builder should attempt to bridge 1000 + 1 (for payment) USDC to chain 8453
+        // Note: There are 2000e6 USDC on each chain, so the Builder should attempt to bridge 1000 USDC to chain 8453
         QuarkBuilder.BuilderResult memory result = builder.swap(
             buyWeth_(8453, usdc_(8453), 3000e6, 1e18, address(0xb0b), BLOCK_TIMESTAMP), // swap 3000 USDC on chain 8453 to 1 WETH
             chainAccountsList_(4000e6), // holding 4000 USDC in total across chains 1, 8453
@@ -684,13 +682,9 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         );
 
         address approveAndSwapAddress = CodeJarHelper.getCodeAddress(type(ApproveAndSwap).creationCode);
-        address paycallAddress = CodeJarHelper.getCodeAddress(
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
-        );
-        address paycallAddressBase = CodeJarHelper.getCodeAddress(
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_8453, USDC_8453))
-        );
         address cctpBridgeActionsAddress = CodeJarHelper.getCodeAddress(type(CCTPBridgeActions).creationCode);
+        address multicallAddress = CodeJarHelper.getCodeAddress(type(Multicall).creationCode);
+        address quotePayAddress = CodeJarHelper.getCodeAddress(type(QuotePay).creationCode);
 
         assertEq(result.paymentCurrency, "usdc", "usdc currency");
 
@@ -698,25 +692,26 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         assertEq(result.quarkOperations.length, 2, "two operations");
         assertEq(
             result.quarkOperations[0].scriptAddress,
-            paycallAddress,
-            "script address[0] has been wrapped with paycall address"
+            multicallAddress,
+            "script address[0] has been wrapped with multicall address"
         );
+        address[] memory callContracts = new address[](2);
+        callContracts[0] = cctpBridgeActionsAddress;
+        callContracts[1] = quotePayAddress;
+        bytes[] memory callDatas = new bytes[](2);
+        callDatas[0] = abi.encodeWithSelector(
+            CCTPBridgeActions.bridgeUSDC.selector,
+            address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
+            1000e6,
+            6,
+            bytes32(uint256(uint160(0xb0b))),
+            usdc_(1)
+        );
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 6e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                cctpBridgeActionsAddress,
-                abi.encodeWithSelector(
-                    CCTPBridgeActions.bridgeUSDC.selector,
-                    address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
-                    1001e6,
-                    6,
-                    bytes32(uint256(uint160(0xb0b))),
-                    usdc_(1)
-                ),
-                5e6
-            ),
-            "calldata is Paycall.run(CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 2.1e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1))), 5e5);"
+            abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
+            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 1000e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1))), QuotePay.pay(address(0xa11ce), USDC_1, 6e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -724,28 +719,13 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         assertEq(result.quarkOperations[0].nonce, ALICE_DEFAULT_SECRET, "unexpected nonce");
         assertEq(result.quarkOperations[0].isReplayable, false, "isReplayable is false");
 
-        assertEq(
-            result.quarkOperations[1].scriptAddress,
-            paycallAddressBase,
-            "script address[1] has been wrapped with paycall address"
-        );
+        assertEq(result.quarkOperations[1].scriptAddress, approveAndSwapAddress, "script address[1] is correct");
         assertEq(
             result.quarkOperations[1].scriptCalldata,
             abi.encodeWithSelector(
-                Paycall.run.selector,
-                approveAndSwapAddress,
-                abi.encodeWithSelector(
-                    ApproveAndSwap.run.selector,
-                    ZERO_EX_ENTRY_POINT,
-                    USDC_8453,
-                    3000e6,
-                    WETH_8453,
-                    1e18,
-                    ZERO_EX_SWAP_DATA
-                ),
-                1e6
+                ApproveAndSwap.run.selector, ZERO_EX_ENTRY_POINT, USDC_8453, 3000e6, WETH_8453, 1e18, ZERO_EX_SWAP_DATA
             ),
-            "calldata is Paycall.run(ApproveAndSwap.run(ZERO_EX_ENTRY_POINT, USDC_8453, 3500e6, WETH_8453, 1e18, ZERO_EX_SWAP_DATA), 5e6);"
+            "calldata is ApproveAndSwap.run(ZERO_EX_ENTRY_POINT, USDC_8453, 3500e6, WETH_8453, 1e18, ZERO_EX_SWAP_DATA);"
         );
         assertEq(
             result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 3 days, "expiry is current blockTimestamp + 3 days"
@@ -770,8 +750,8 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                     price: USDC_PRICE,
                     token: USDC_1,
                     assetSymbol: "USDC",
-                    inputAmount: 1001e6,
-                    outputAmount: 1001e6,
+                    inputAmount: 1000e6,
+                    outputAmount: 1000e6,
                     chainId: 1,
                     recipient: address(0xb0b),
                     destinationChainId: 8453,
@@ -817,7 +797,7 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
     }
 
-    function testBridgeSwapMaxWithQuotecallSucceeds() public {
+    function testBridgeSwapMaxWithQuotePaySucceeds() public {
         QuarkBuilder builder = new QuarkBuilder();
         PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
         maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 5e6});
@@ -829,13 +809,9 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         );
 
         address approveAndSwapAddress = CodeJarHelper.getCodeAddress(type(ApproveAndSwap).creationCode);
-        address quotecallAddress = CodeJarHelper.getCodeAddress(
-            abi.encodePacked(type(Quotecall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
-        );
-        address quotecallAddressBase = CodeJarHelper.getCodeAddress(
-            abi.encodePacked(type(Quotecall).creationCode, abi.encode(ETH_USD_PRICE_FEED_8453, USDC_8453))
-        );
         address cctpBridgeActionsAddress = CodeJarHelper.getCodeAddress(type(CCTPBridgeActions).creationCode);
+        address multicallAddress = CodeJarHelper.getCodeAddress(type(Multicall).creationCode);
+        address quotePayAddress = CodeJarHelper.getCodeAddress(type(QuotePay).creationCode);
 
         assertEq(result.paymentCurrency, "usdc", "usdc currency");
 
@@ -843,25 +819,27 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         assertEq(result.quarkOperations.length, 2, "two operations");
         assertEq(
             result.quarkOperations[0].scriptAddress,
-            quotecallAddress,
-            "script address[0] has been wrapped with quotecall address"
+            multicallAddress,
+            "script address[0] has been wrapped with multicall address"
         );
+        // Max swap amount should be 6010e6 - 6e6 (cost) = 6004e6, which means we bridge over 2999e6 (chain 8453 already has 3005e6, so only needs 2999e6 more)
+        address[] memory callContracts = new address[](2);
+        callContracts[0] = cctpBridgeActionsAddress;
+        callContracts[1] = quotePayAddress;
+        bytes[] memory callDatas = new bytes[](2);
+        callDatas[0] = abi.encodeWithSelector(
+            CCTPBridgeActions.bridgeUSDC.selector,
+            address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
+            2999e6,
+            6,
+            bytes32(uint256(uint160(0xb0b))),
+            usdc_(1)
+        );
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 6e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Quotecall.run.selector,
-                cctpBridgeActionsAddress,
-                abi.encodeWithSelector(
-                    CCTPBridgeActions.bridgeUSDC.selector,
-                    address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
-                    3000e6,
-                    6,
-                    bytes32(uint256(uint160(0xb0b))),
-                    usdc_(1)
-                ),
-                5e6
-            ),
-            "calldata is Quotecall.run(CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 3000e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1))), 5e5);"
+            abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
+            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 2999e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1))), QuotePay.pay(address(0xa11ce), USDC_1, 6e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -869,28 +847,13 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         assertEq(result.quarkOperations[0].nonce, ALICE_DEFAULT_SECRET, "unexpected nonce");
         assertEq(result.quarkOperations[0].isReplayable, false, "isReplayable is false");
 
-        assertEq(
-            result.quarkOperations[1].scriptAddress,
-            quotecallAddressBase,
-            "script address[1] has been wrapped with quotecall address"
-        );
+        assertEq(result.quarkOperations[1].scriptAddress, approveAndSwapAddress, "script address[1] is correct");
         assertEq(
             result.quarkOperations[1].scriptCalldata,
             abi.encodeWithSelector(
-                Quotecall.run.selector,
-                approveAndSwapAddress,
-                abi.encodeWithSelector(
-                    ApproveAndSwap.run.selector,
-                    ZERO_EX_ENTRY_POINT,
-                    USDC_8453,
-                    6004e6,
-                    WETH_8453,
-                    2e18,
-                    ZERO_EX_SWAP_DATA
-                ),
-                1e6
+                ApproveAndSwap.run.selector, ZERO_EX_ENTRY_POINT, USDC_8453, 6004e6, WETH_8453, 2e18, ZERO_EX_SWAP_DATA
             ),
-            "calldata is Quotecall.run(ApproveAndSwap.run(ZERO_EX_ENTRY_POINT, USDC_8453, 3500e6, WETH_8453, 1e18, ZERO_EX_SWAP_DATA), 5e6);"
+            "calldata is ApproveAndSwap.run(ZERO_EX_ENTRY_POINT, USDC_8453, 3500e6, WETH_8453, 1e18, ZERO_EX_SWAP_DATA);"
         );
         assertEq(
             result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 3 days, "expiry is current blockTimestamp + 3 days"
@@ -915,8 +878,8 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                     price: USDC_PRICE,
                     token: USDC_1,
                     assetSymbol: "USDC",
-                    inputAmount: 3000e6,
-                    outputAmount: 3000e6,
+                    inputAmount: 2999e6,
+                    outputAmount: 2999e6,
                     chainId: 1,
                     recipient: address(0xb0b),
                     destinationChainId: 8453,
@@ -956,151 +919,6 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
             "action context encoded from SwapActionContext"
         );
 
-        // TODO: Check the contents of the EIP712 data
-        assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
-        assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");
-        assertNotEq(result.eip712Data.hashStruct, hex"", "non-empty hashStruct");
-    }
-
-    function testBridgeSwapBridgesPaymentToken() public {
-        QuarkBuilder builder = new QuarkBuilder();
-        PaymentInfo.PaymentMaxCost[] memory maxCosts = new PaymentInfo.PaymentMaxCost[](2);
-        maxCosts[0] = PaymentInfo.PaymentMaxCost({chainId: 1, amount: 5e6});
-        maxCosts[1] = PaymentInfo.PaymentMaxCost({chainId: 8453, amount: 3500e6});
-        // Note: There are 3000e6 USDC on each chain, so the Builder should attempt to bridge 500 USDC to chain 8453 to cover the max cost
-        QuarkBuilder.BuilderResult memory result = builder.swap(
-            buyWeth_(8453, usdt_(8453), 3000e6, 1e18, address(0xb0b), BLOCK_TIMESTAMP), // swap 3000 USDT on chain 8453 to 1 WETH
-            chainAccountsList_(6000e6), // holding 6000 USDC and USDT in total across chains 1, 8453
-            paymentUsdc_(maxCosts)
-        );
-
-        address approveAndSwapAddress = CodeJarHelper.getCodeAddress(type(ApproveAndSwap).creationCode);
-        address paycallAddress = CodeJarHelper.getCodeAddress(
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_1, USDC_1))
-        );
-        address paycallAddressBase = CodeJarHelper.getCodeAddress(
-            abi.encodePacked(type(Paycall).creationCode, abi.encode(ETH_USD_PRICE_FEED_8453, USDC_8453))
-        );
-        address cctpBridgeActionsAddress = CodeJarHelper.getCodeAddress(type(CCTPBridgeActions).creationCode);
-
-        assertEq(result.paymentCurrency, "usdc", "usdc currency");
-
-        // Check the quark operations
-        assertEq(result.quarkOperations.length, 2, "two operations");
-        assertEq(
-            result.quarkOperations[0].scriptAddress,
-            paycallAddress,
-            "script address[0] has been wrapped with paycall address"
-        );
-        assertEq(
-            result.quarkOperations[0].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                cctpBridgeActionsAddress,
-                abi.encodeWithSelector(
-                    CCTPBridgeActions.bridgeUSDC.selector,
-                    address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155),
-                    500e6,
-                    6,
-                    bytes32(uint256(uint160(0xb0b))),
-                    usdc_(1)
-                ),
-                5e6
-            ),
-            "calldata is Paycall.run(CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 500e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1))), 5e6);"
-        );
-        assertEq(
-            result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
-        );
-        assertEq(result.quarkOperations[0].nonce, ALICE_DEFAULT_SECRET, "unexpected nonce");
-        assertEq(result.quarkOperations[0].isReplayable, false, "isReplayable is false");
-
-        assertEq(
-            result.quarkOperations[1].scriptCalldata,
-            abi.encodeWithSelector(
-                Paycall.run.selector,
-                approveAndSwapAddress,
-                abi.encodeWithSelector(
-                    ApproveAndSwap.run.selector,
-                    ZERO_EX_ENTRY_POINT,
-                    USDT_8453,
-                    3000e6,
-                    WETH_8453,
-                    1e18,
-                    ZERO_EX_SWAP_DATA
-                ),
-                3500e6
-            ),
-            "calldata is Paycall.run(ApproveAndSwap.run(ZERO_EX_ENTRY_POINT, USDT_8453, 3500e6, WETH_8453, 1e18, ZERO_EX_SWAP_DATA), 3500e6);"
-        );
-        assertEq(
-            result.quarkOperations[1].scriptAddress,
-            paycallAddressBase,
-            "script address[1] has been wrapped with paycall address"
-        );
-        assertEq(
-            result.quarkOperations[1].expiry, BLOCK_TIMESTAMP + 3 days, "expiry is current blockTimestamp + 3 days"
-        );
-        assertEq(result.quarkOperations[1].nonce, BOB_DEFAULT_SECRET, "unexpected nonce");
-        assertEq(result.quarkOperations[1].isReplayable, false, "isReplayable is false");
-
-        // Check the actions
-        assertEq(result.actions.length, 2, "one action");
-        assertEq(result.actions[0].chainId, 1, "operation is on chainid 1");
-        assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
-        assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
-        assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-        assertEq(result.actions[0].paymentMaxCost, 5e6, "payment should have max cost of 5e6");
-        assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
-        assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
-        assertEq(
-            result.actions[0].actionContext,
-            abi.encode(
-                Actions.BridgeActionContext({
-                    price: USDC_PRICE,
-                    token: USDC_1,
-                    assetSymbol: "USDC",
-                    inputAmount: 500e6,
-                    outputAmount: 500e6,
-                    chainId: 1,
-                    recipient: address(0xb0b),
-                    destinationChainId: 8453,
-                    bridgeType: Actions.BRIDGE_TYPE_CCTP
-                })
-            ),
-            "action context encoded from BridgeActionContext"
-        );
-        assertEq(result.actions[1].chainId, 8453, "operation is on chainid 8453");
-        assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
-        assertEq(result.actions[1].actionType, "SWAP", "action type is 'SWAP'");
-        assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
-        assertEq(result.actions[1].paymentMaxCost, 3500e6, "payment should have max cost of 3500e6");
-        assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
-        assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
-        assertEq(
-            result.actions[1].actionContext,
-            abi.encode(
-                Actions.SwapActionContext({
-                    chainId: 8453,
-                    feeAmount: 10,
-                    feeAssetSymbol: "WETH",
-                    feeToken: WETH_8453,
-                    feeTokenPrice: WETH_PRICE,
-                    inputToken: USDT_8453,
-                    inputTokenPrice: USDT_PRICE,
-                    inputAssetSymbol: "USDT",
-                    inputAmount: 3000e6,
-                    outputToken: WETH_8453,
-                    outputTokenPrice: WETH_PRICE,
-                    outputAssetSymbol: "WETH",
-                    outputAmount: 1e18,
-                    isExactOut: false
-                })
-            ),
-            "action context encoded from SwapActionContext"
-        );
         // TODO: Check the contents of the EIP712 data
         assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
         assertNotEq(result.eip712Data.domainSeparator, hex"", "non-empty domain separator");

--- a/test/builder/QuarkBuilderSwap.t.sol
+++ b/test/builder/QuarkBuilderSwap.t.sol
@@ -362,11 +362,11 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         callDatas[0] = abi.encodeWithSelector(
             ApproveAndSwap.run.selector, ZERO_EX_ENTRY_POINT, USDC_1, 3000e6, WETH_1, 1e18, ZERO_EX_SWAP_DATA
         );
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 5e6, QUOTE_ID);
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 5e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([approveAndSwapAddress, quotePayAddress], [ApproveAndSwap.run(ZERO_EX_ENTRY_POINT, USDC_1, 3500e6, WETH_1, 1e18, ZERO_EX_SWAP_DATA), QuotePay.pay(address(0xa11ce), USDC_1, 5e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([approveAndSwapAddress, quotePayAddress], [ApproveAndSwap.run(ZERO_EX_ENTRY_POINT, USDC_1, 3500e6, WETH_1, 1e18, ZERO_EX_SWAP_DATA), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 5e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 3 days, "expiry is current blockTimestamp + 3 days"
@@ -469,11 +469,11 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         callDatas[0] = abi.encodeWithSelector(
             ApproveAndSwap.run.selector, ZERO_EX_ENTRY_POINT, USDC_1, 9000e6, WETH_1, 3e18, ZERO_EX_SWAP_DATA
         );
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 5e6, QUOTE_ID);
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 5e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([approveAndSwapAddress, quotePayAddress], [ApproveAndSwap.run(ZERO_EX_ENTRY_POINT, USDC_1, 9000e6, WETH_1, 3e18, ZERO_EX_SWAP_DATA), QuotePay.pay(address(0xa11ce), USDC_1, 5e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([approveAndSwapAddress, quotePayAddress], [ApproveAndSwap.run(ZERO_EX_ENTRY_POINT, USDC_1, 9000e6, WETH_1, 3e18, ZERO_EX_SWAP_DATA), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 5e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 3 days, "expiry is current blockTimestamp + 3 days"
@@ -707,11 +707,11 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
             bytes32(uint256(uint160(0xb0b))),
             usdc_(1)
         );
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 6e6, QUOTE_ID);
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 6e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 1000e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1))), QuotePay.pay(address(0xa11ce), USDC_1, 6e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 1000e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1))), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 6e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -835,11 +835,11 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
             bytes32(uint256(uint160(0xb0b))),
             usdc_(1)
         );
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 6e6, QUOTE_ID);
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 6e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 2999e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1))), QuotePay.pay(address(0xa11ce), USDC_1, 6e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 2999e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1))), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 6e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"

--- a/test/builder/QuarkBuilderTransfer.t.sol
+++ b/test/builder/QuarkBuilderTransfer.t.sol
@@ -452,11 +452,11 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
             bytes32(uint256(uint160(0xb0b))),
             usdc_(1)
         );
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 6e5, QUOTE_ID);
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 6e5, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 2e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1)), QuotePay.pay(address(0xa11ce), USDC_1, 6e5, QUOTE_ID)]);"
+            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 2e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1)), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 6e5, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -578,11 +578,11 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
             address(0xceecee),
             9.9e6
         );
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 1e5, QUOTE_ID);
+        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 1e5, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([transferActionsAddress, quotePayAddress], [TransferActions.transferERC20Token(USDC_1, address(0xceecee), 9.9e6), QuotePay.pay(address(0xa11ce), USDC_1, 6e5, QUOTE_ID)]);"
+            "calldata is Multicall.run([transferActionsAddress, quotePayAddress], [TransferActions.transferERC20Token(USDC_1, address(0xceecee), 9.9e6), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 6e5, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -690,11 +690,12 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
             usdc_(1)
         );
         // TODO: should be 0xb0b
-        callDatas[1] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.6e6, QUOTE_ID);
+        callDatas[1] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.6e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 7.4e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1), QuotePay.pay(address(0xa11ce), USDC_1, 0.6e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([cctpBridgeActionsAddress, quotePayAddress], [CCTPBridgeActions.bridgeUSDC(address(0xBd3fa81B58Ba92a82136038B25aDec7066af3155), 7.4e6, 6, bytes32(uint256(uint160(0xb0b))), usdc_(1), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.6e6, QUOTE_ID)]);"
         );
         assertEq(result.quarkOperations[0].scriptSources.length, 3);
         assertEq(result.quarkOperations[0].scriptSources[0], type(CCTPBridgeActions).creationCode);
@@ -1014,11 +1015,12 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
             WrapperActions.unwrapWETHUpTo.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1.5e18
         );
         callDatas[1] = abi.encodeWithSelector(TransferActions.transferNativeToken.selector, address(0xceecee), 1.5e18);
-        callDatas[2] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID);
+        callDatas[2] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.1e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),
-            "calldata is Multicall.run([wrapperActionsAddress, transferActionsAddress, quotePayAddress], [WrapperActions.unwrapWETHUpTo(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1.5e18), TransferActions.transferNativeToken(address(0xceecee), 1.5e18), QuotePay.pay(address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID)]);"
+            "calldata is Multicall.run([wrapperActionsAddress, transferActionsAddress, quotePayAddress], [WrapperActions.unwrapWETHUpTo(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 1.5e18), TransferActions.transferNativeToken(address(0xceecee), 1.5e18), QuotePay.pay(Actions.QUOTE_PAY_RECIPIENT), USDC_1, 0.1e6, QUOTE_ID)]);"
         );
         assertEq(
             result.quarkOperations[0].expiry, BLOCK_TIMESTAMP + 7 days, "expiry is current blockTimestamp + 7 days"
@@ -1122,7 +1124,8 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
             WrapperActions.unwrapWETHUpTo.selector, 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, 2e18
         );
         callDatas[1] = abi.encodeWithSelector(TransferActions.transferNativeToken.selector, address(0xceecee), 2e18);
-        callDatas[2] = abi.encodeWithSelector(QuotePay.pay.selector, address(0xa11ce), USDC_1, 0.1e6, QUOTE_ID);
+        callDatas[2] =
+            abi.encodeWithSelector(QuotePay.pay.selector, Actions.QUOTE_PAY_RECIPIENT, USDC_1, 0.1e6, QUOTE_ID);
         assertEq(
             result.quarkOperations[0].scriptCalldata,
             abi.encodeWithSelector(Multicall.run.selector, callContracts, callDatas),

--- a/test/builder/QuarkBuilderTransfer.t.sol
+++ b/test/builder/QuarkBuilderTransfer.t.sol
@@ -14,12 +14,9 @@ import {TransferActionsBuilder} from "src/builder/actions/TransferActionsBuilder
 import {Actions} from "src/builder/actions/Actions.sol";
 import {Accounts} from "src/builder/Accounts.sol";
 import {CodeJarHelper} from "src/builder/CodeJarHelper.sol";
-import {Paycall} from "src/Paycall.sol";
-import {PaycallWrapper} from "src/builder/PaycallWrapper.sol";
 import {PaymentInfo} from "src/builder/PaymentInfo.sol";
 import {QuarkBuilder} from "src/builder/QuarkBuilder.sol";
 import {QuarkBuilderBase} from "src/builder/QuarkBuilderBase.sol";
-import {Quotecall} from "src/Quotecall.sol";
 import {QuotePay} from "src/QuotePay.sol";
 
 contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {

--- a/test/builder/QuarkBuilderTransfer.t.sol
+++ b/test/builder/QuarkBuilderTransfer.t.sol
@@ -112,7 +112,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         });
     }
 
-    function testInsufficientFunds() public {
+    function testTransferInsufficientFunds() public {
         TransferActionsBuilder.TransferIntent memory intent = transferUsdc_(1, 10e6, address(0xc0b), BLOCK_TIMESTAMP); // transfer 10 USDC on chain 1 to 0xc0b
         intent.paymentAssetSymbol = "USD";
 
@@ -125,9 +125,9 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         );
     }
 
-    function testMaxCostTooHigh() public {
+    function testTransferMaxCostTooHigh() public {
         QuarkBuilder builder = new QuarkBuilder();
-        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "USDC"));
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.ImpossibleToConstructQuotePay.selector, "USDC"));
         builder.transfer(
             transferUsdc_(1, 1e6, address(0xc0b), BLOCK_TIMESTAMP), // transfer 1 USDC on chain 1 to 0xc0b
             chainAccountsList_(2e6), // holding 2 USDC in total across 1, 8453
@@ -135,7 +135,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         );
     }
 
-    function testFundsOnUnbridgeableChains() public {
+    function testTransferFundsOnUnbridgeableChains() public {
         TransferActionsBuilder.TransferIntent memory intent = transferUsdc_(7777, 2e6, address(0xc0b), BLOCK_TIMESTAMP); // transfer 2 USDC on chain 7777 to 0xc0b
         intent.paymentAssetSymbol = "USD";
 
@@ -150,7 +150,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         );
     }
 
-    function testFundsUnavailableErrorGivesSuggestionForAvailableFunds() public {
+    function testTransferFundsUnavailableErrorGivesSuggestionForAvailableFunds() public {
         QuarkBuilder builder = new QuarkBuilder();
         // The 100e6 is the suggested amount (total available funds) to transfer
         vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.FundsUnavailable.selector, "USDC", 105e6, 100e6));
@@ -161,11 +161,11 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         );
     }
 
-    function testUnableToConstructQuotePay() public {
+    function testTransferUnableToConstructQuotePay() public {
         QuarkBuilder builder = new QuarkBuilder();
         // User has enough to transfer, but not enough for the QuotePay because no quote is given on chain 8453 and all
         // the funds are used on chain 1 for the transfer
-        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "USDC"));
+        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructQuotePay.selector, "USDC", 3e6));
         builder.transfer(
             transferUsdc_(1, 100e6, address(0xc0b), BLOCK_TIMESTAMP), // transfer 100 USDC on chain 1 to 0xc0b
             chainAccountsList_(200e6), // holding 200 USDC in total across 1, 8453

--- a/test/builder/Quotes.t.sol
+++ b/test/builder/Quotes.t.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity ^0.8.27;
+
+import "forge-std/Test.sol";
+
+import {Accounts} from "src/builder/Accounts.sol";
+import {PaymentInfo} from "src/builder/PaymentInfo.sol";
+import {Quotes} from "src/builder/Quotes.sol";
+
+import {QuarkBuilderTest} from "test/builder/lib/QuarkBuilderTest.sol";
+
+contract QuotesTest is Test, QuarkBuilderTest {
+    function testConvertingQuotesToPayment() public {
+        Accounts.ChainAccounts[] memory chainAccountsList = chainAccountsList_(6e6);
+        Quotes.AssetQuote memory assetQuote = Quotes.AssetQuote({symbol: "USDC", price: 1e8});
+
+        Quotes.AssetQuote[] memory assetQuotes = new Quotes.AssetQuote[](1);
+        assetQuotes[0] = assetQuote;
+
+        Quotes.NetworkOperationFee memory networkOperationFee =
+            Quotes.NetworkOperationFee({chainId: 8453, opType: Quotes.OP_TYPE_BASELINE, price: 3e6});
+
+        Quotes.NetworkOperationFee[] memory networkOperationFees = new Quotes.NetworkOperationFee[](1);
+        networkOperationFees[0] = networkOperationFee;
+
+        bytes32 quoteId = 0xdeadbeef00000000000000000000000000000000000000000000000000000000;
+        Quotes.Quote memory quote = Quotes.Quote({
+            quoteId: quoteId,
+            issuedAt: 1704067200,
+            expiresAt: 1704069200,
+            assetQuotes: assetQuotes,
+            networkOperationFees: networkOperationFees
+        });
+        string memory symbol = "USDC";
+        PaymentInfo.Payment memory result = Quotes.getPaymentFromQuotesAndSymbol(chainAccountsList, quote, symbol);
+
+        assertEq(result.isToken, true, "isToken is set to true");
+        assertEq(result.currency, symbol, "currency is set to passed in symbol");
+        assertEq(result.quoteId, quote.quoteId, "quoteId is set to quiteId from quote");
+        assertEq(
+            result.maxCosts[0].chainId, networkOperationFee.chainId, "chainId is set to networkOperationFee chainId"
+        );
+        assertEq(result.maxCosts[0].amount, 3e4, "amount is set to networkOperationFee in units of token");
+    }
+
+    function testConvertingQuotesToPaymentForUsd() public {
+        Accounts.ChainAccounts[] memory chainAccountsList = chainAccountsList_(6e6);
+        Quotes.AssetQuote memory assetQuote = Quotes.AssetQuote({symbol: "USDC", price: 1e8});
+
+        Quotes.AssetQuote[] memory assetQuotes = new Quotes.AssetQuote[](1);
+        assetQuotes[0] = assetQuote;
+
+        Quotes.NetworkOperationFee memory networkOperationFee =
+            Quotes.NetworkOperationFee({chainId: 8453, opType: Quotes.OP_TYPE_BASELINE, price: 3e6});
+
+        Quotes.NetworkOperationFee[] memory networkOperationFees = new Quotes.NetworkOperationFee[](1);
+        networkOperationFees[0] = networkOperationFee;
+
+        bytes32 quoteId = 0xdeadbeef00000000000000000000000000000000000000000000000000000000;
+        Quotes.Quote memory quote = Quotes.Quote({
+            quoteId: quoteId,
+            issuedAt: 1704067200,
+            expiresAt: 1704069200,
+            assetQuotes: assetQuotes,
+            networkOperationFees: networkOperationFees
+        });
+        string memory symbol = "USD";
+        PaymentInfo.Payment memory result = Quotes.getPaymentFromQuotesAndSymbol(chainAccountsList, quote, symbol);
+
+        assertEq(result.isToken, false, "isToken is set to false");
+        assertEq(result.currency, symbol, "currency is set to passed in symbol");
+        assertEq(result.quoteId, quote.quoteId, "quoteId is set to quiteId from quote");
+        assertEq(result.maxCosts.length, 0, "maxCosts are not set");
+    }
+}

--- a/test/builder/lib/QuarkBuilderTest.sol
+++ b/test/builder/lib/QuarkBuilderTest.sol
@@ -10,6 +10,7 @@ import {Paycall} from "src/Paycall.sol";
 import {Quotecall} from "src/Quotecall.sol";
 import {PaymentInfo} from "src/builder/PaymentInfo.sol";
 import {QuarkBuilder} from "src/builder/QuarkBuilder.sol";
+import {Quotes} from "src/builder/Quotes.sol";
 import {Strings} from "src/builder/Strings.sol";
 import {MorphoInfo} from "src/builder/MorphoInfo.sol";
 import {Arrays} from "test/builder/lib/Arrays.sol";
@@ -91,6 +92,51 @@ contract QuarkBuilderTest {
         returns (PaymentInfo.Payment memory)
     {
         return PaymentInfo.Payment({isToken: false, currency: "usd", quoteId: bytes32(""), maxCosts: maxCosts});
+    }
+
+    function quote_() internal pure returns (Quotes.Quote memory) {
+        Quotes.NetworkOperationFee memory networkOperationFeeBase =
+            Quotes.NetworkOperationFee({chainId: 8453, opType: Quotes.OP_TYPE_BASELINE, price: 3e6});
+
+        Quotes.NetworkOperationFee memory networkOperationFeeMainnet =
+            Quotes.NetworkOperationFee({chainId: 1, opType: Quotes.OP_TYPE_BASELINE, price: 3e8});
+
+        Quotes.NetworkOperationFee[] memory networkOperationFees = new Quotes.NetworkOperationFee[](2);
+        networkOperationFees[0] = networkOperationFeeBase;
+        networkOperationFees[1] = networkOperationFeeMainnet;
+
+        return quote_(networkOperationFees);
+    }
+
+    function quote_(uint256 chainId, uint256 price) internal pure returns (Quotes.Quote memory) {
+        Quotes.NetworkOperationFee memory networkOperationFee =
+            Quotes.NetworkOperationFee({chainId: chainId, opType: Quotes.OP_TYPE_BASELINE, price: price});
+
+        Quotes.NetworkOperationFee[] memory networkOperationFees = new Quotes.NetworkOperationFee[](1);
+        networkOperationFees[0] = networkOperationFee;
+
+        return quote_(networkOperationFees);
+    }
+
+    function quote_(Quotes.NetworkOperationFee[] memory networkOperationFees)
+        internal
+        pure
+        returns (Quotes.Quote memory)
+    {
+        Quotes.AssetQuote memory assetQuoteUsd = Quotes.AssetQuote({symbol: "USD", price: 1e8});
+        Quotes.AssetQuote memory assetQuoteUsdc = Quotes.AssetQuote({symbol: "USDC", price: 1e8});
+
+        Quotes.AssetQuote[] memory assetQuotes = new Quotes.AssetQuote[](2);
+        assetQuotes[0] = assetQuoteUsd;
+        assetQuotes[1] = assetQuoteUsdc;
+
+        return Quotes.Quote({
+            quoteId: QUOTE_ID,
+            issuedAt: 1704067200,
+            expiresAt: 1704069200,
+            assetQuotes: assetQuotes,
+            networkOperationFees: networkOperationFees
+        });
     }
 
     // TODO: refactor

--- a/test/builder/lib/QuarkBuilderTest.sol
+++ b/test/builder/lib/QuarkBuilderTest.sol
@@ -59,6 +59,8 @@ contract QuarkBuilderTest {
     bytes32 constant BOB_DEFAULT_SECRET = bytes32(uint256(2));
     bytes32 constant COB_DEFAULT_SECRET = bytes32(uint256(5));
 
+    bytes32 constant QUOTE_ID = bytes32("QUOTE_ID");
+
     /**
      *
      * Fixture Functions
@@ -76,7 +78,7 @@ contract QuarkBuilderTest {
         pure
         returns (PaymentInfo.Payment memory)
     {
-        return PaymentInfo.Payment({isToken: true, currency: "usdc", maxCosts: maxCosts});
+        return PaymentInfo.Payment({isToken: true, currency: "usdc", quoteId: QUOTE_ID, maxCosts: maxCosts});
     }
 
     function paymentUsd_() internal pure returns (PaymentInfo.Payment memory) {
@@ -88,7 +90,7 @@ contract QuarkBuilderTest {
         pure
         returns (PaymentInfo.Payment memory)
     {
-        return PaymentInfo.Payment({isToken: false, currency: "usd", maxCosts: maxCosts});
+        return PaymentInfo.Payment({isToken: false, currency: "usd", quoteId: bytes32(""), maxCosts: maxCosts});
     }
 
     // TODO: refactor


### PR DESCRIPTION
Introduces `QuotePay` to the QuarkBuilder. Rather than wrapping operations around a Paycall/Quotecall to pay for operations, a `QuotePay` is used instead. `QuotePay` takes an amount (e.g. quote) and transfers that from the user to a payee. A `QuotePay` can be made on any chain that the user has enough payment assets on, which means we no longer have to deal with the complexities of bridging payment tokens.

The quote that the `QuotePay` uses is passed in by the client. Currently, only the `transfer` builder function supports this new Quote interface. We plan to update the interfaces for the other builder functions as well in a follow up PR.