### PR TITLE
Add quotePayActionContext to Action

### DIFF
--- a/src/builder/QuarkBuilderBase.sol
+++ b/src/builder/QuarkBuilderBase.sol
@@ -22,7 +22,7 @@ import {List} from "src/builder/List.sol";
 import {HashMap} from "src/builder/HashMap.sol";
 import {QuotePay} from "src/QuotePay.sol";
 
-string constant QUARK_BUILDER_VERSION = "0.4.0";
+string constant QUARK_BUILDER_VERSION = "0.4.1";
 
 contract QuarkBuilderBase {
     /* ===== Output Types ===== */
@@ -437,7 +437,7 @@ contract QuarkBuilderBase {
         HashMap.Map memory assetsInPerChain = HashMap.newMap();
         HashMap.Map memory assetsOutPerChain = HashMap.newMap();
 
-        string memory paymentTokenSymbol = args.actions[0].paymentTokenSymbol; // assumes all actions use the same payment token
+        string memory paymentTokenSymbol = args.payment.currency;
         for (uint256 i = 0; i < args.actions.length; ++i) {
             Actions.Action memory action = args.actions[i];
 
@@ -453,6 +453,7 @@ contract QuarkBuilderBase {
                 action: action,
                 actionIntent: args.actionIntent,
                 chainAccountsList: args.chainAccountsList,
+                paymentTokenSymbol: paymentTokenSymbol,
                 account: args.account
             });
         }
@@ -560,7 +561,7 @@ contract QuarkBuilderBase {
         HashMap.Map memory assetsInPerChain = HashMap.newMap();
         HashMap.Map memory assetsOutPerChain = HashMap.newMap();
 
-        string memory paymentTokenSymbol = args.actions[0].paymentTokenSymbol; // assumes all actions use the same payment token
+        string memory paymentTokenSymbol = args.payment.currency;
         for (uint256 i = 0; i < args.actions.length; ++i) {
             Actions.Action memory action = args.actions[i];
 
@@ -570,6 +571,7 @@ contract QuarkBuilderBase {
                 action: action,
                 actionIntent: args.actionIntent,
                 chainAccountsList: args.chainAccountsList,
+                paymentTokenSymbol: paymentTokenSymbol,
                 account: args.account
             });
         }
@@ -613,10 +615,9 @@ contract QuarkBuilderBase {
         Actions.Action memory action,
         ActionIntent memory actionIntent,
         Accounts.ChainAccounts[] memory chainAccountsList,
+        string memory paymentTokenSymbol,
         address account
     ) internal pure {
-        string memory paymentTokenSymbol = action.paymentTokenSymbol;
-
         // Depending on the action type, update the `assetsInPerChain` and/or `assetsOutPerChain` maps
         if (Strings.stringEqIgnoreCase(action.actionType, Actions.ACTION_TYPE_BRIDGE)) {
             Actions.BridgeActionContext memory bridgeActionContext =

--- a/src/builder/QuarkOperationHelper.sol
+++ b/src/builder/QuarkOperationHelper.sol
@@ -114,6 +114,13 @@ library QuarkOperationHelper {
             primaryQuarkOperation = quarkOperations[quarkOperations.length - 1];
             primaryAction = actions[actions.length - 1];
         }
+        // Find and attach a QuotePay action context if one is found
+        for (uint256 i = 0; i < actions.length; ++i) {
+            if (Strings.stringEq(actions[i].actionType, Actions.ACTION_TYPE_QUOTE_PAY)) {
+                primaryAction.quotePayActionContext = actions[i].actionContext;
+                break;
+            }
+        }
         IQuarkWallet.QuarkOperation memory mergedQuarkOperation = IQuarkWallet.QuarkOperation({
             nonce: primaryQuarkOperation.nonce,
             isReplayable: primaryQuarkOperation.isReplayable,

--- a/src/builder/actions/Actions.sol
+++ b/src/builder/actions/Actions.sol
@@ -285,14 +285,10 @@ library Actions {
         address quarkAccount;
         string actionType;
         bytes actionContext;
+        // The action context for a QuotePay, if one exists for this operation. Otherwise, empty bytes
+        bytes quotePayActionContext;
         // One of the PaymentInfo.PAYMENT_METHOD_* constants.
         string paymentMethod;
-        // Address of payment token on chainId.
-        // Null address if the payment method was OFFCHAIN.
-        address paymentToken;
-        string paymentTokenSymbol;
-        // TODO: might need to change this/remove this since payment isn't being made on each chain
-        uint256 paymentMaxCost;
         // The secret used to generate the hash chain for a replayable operation. For non-replayable
         // operations, the `nonce` will be the `nonceSecret` (the hash chain has a length of 1)
         bytes32 nonceSecret;
@@ -674,12 +670,8 @@ library Actions {
             quarkAccount: bridge.sender,
             actionType: ACTION_TYPE_BRIDGE,
             actionContext: abi.encode(bridgeActionContext),
+            quotePayActionContext: "",
             paymentMethod: PaymentInfo.paymentMethodForPayment(payment, useQuotecall),
-            paymentToken: payment.isToken
-                ? PaymentInfo.knownToken(payment.currency, bridge.srcChainId).token
-                : PaymentInfo.NON_TOKEN_PAYMENT,
-            paymentTokenSymbol: payment.currency,
-            paymentMaxCost: payment.isToken ? PaymentInfo.findMaxCost(payment, bridge.srcChainId) : 0,
             nonceSecret: accountSecret.nonceSecret,
             totalPlays: 1
         });
@@ -764,12 +756,8 @@ library Actions {
             quarkAccount: bridge.sender,
             actionType: ACTION_TYPE_BRIDGE,
             actionContext: abi.encode(bridgeActionContext),
+            quotePayActionContext: "",
             paymentMethod: PaymentInfo.paymentMethodForPayment(payment, useQuotecall),
-            paymentToken: payment.isToken
-                ? PaymentInfo.knownToken(payment.currency, bridge.srcChainId).token
-                : PaymentInfo.NON_TOKEN_PAYMENT,
-            paymentTokenSymbol: payment.currency,
-            paymentMaxCost: payment.isToken ? PaymentInfo.findMaxCost(payment, bridge.srcChainId) : 0,
             nonceSecret: accountSecret.nonceSecret,
             totalPlays: 1
         });
@@ -842,12 +830,8 @@ library Actions {
             quarkAccount: borrowInput.borrower,
             actionType: ACTION_TYPE_BORROW,
             actionContext: abi.encode(borrowActionContext),
+            quotePayActionContext: "",
             paymentMethod: PaymentInfo.paymentMethodForPayment(payment, false),
-            paymentToken: payment.isToken
-                ? PaymentInfo.knownToken(payment.currency, borrowInput.chainId).token
-                : PaymentInfo.NON_TOKEN_PAYMENT,
-            paymentTokenSymbol: payment.currency,
-            paymentMaxCost: payment.isToken ? PaymentInfo.findMaxCost(payment, borrowInput.chainId) : 0,
             nonceSecret: accountSecret.nonceSecret,
             totalPlays: 1
         });
@@ -919,12 +903,8 @@ library Actions {
             quarkAccount: repayInput.repayer,
             actionType: ACTION_TYPE_REPAY,
             actionContext: abi.encode(repayActionContext),
+            quotePayActionContext: "",
             paymentMethod: PaymentInfo.paymentMethodForPayment(payment, false),
-            paymentToken: payment.isToken
-                ? PaymentInfo.knownToken(payment.currency, repayInput.chainId).token
-                : PaymentInfo.NON_TOKEN_PAYMENT,
-            paymentTokenSymbol: payment.currency,
-            paymentMaxCost: payment.isToken ? PaymentInfo.findMaxCost(payment, repayInput.chainId) : 0,
             nonceSecret: accountSecret.nonceSecret,
             totalPlays: 1
         });
@@ -980,12 +960,8 @@ library Actions {
             quarkAccount: cometSupply.sender,
             actionType: ACTION_TYPE_SUPPLY,
             actionContext: abi.encode(cometSupplyActionContext),
+            quotePayActionContext: "",
             paymentMethod: PaymentInfo.paymentMethodForPayment(payment, false),
-            paymentToken: payment.isToken
-                ? PaymentInfo.knownToken(payment.currency, cometSupply.chainId).token
-                : PaymentInfo.NON_TOKEN_PAYMENT,
-            paymentTokenSymbol: payment.currency,
-            paymentMaxCost: payment.isToken ? PaymentInfo.findMaxCost(payment, cometSupply.chainId) : 0,
             nonceSecret: accountSecret.nonceSecret,
             totalPlays: 1
         });
@@ -1042,12 +1018,8 @@ library Actions {
             quarkAccount: cometWithdraw.withdrawer,
             actionType: ACTION_TYPE_WITHDRAW,
             actionContext: abi.encode(cometWithdrawActionContext),
+            quotePayActionContext: "",
             paymentMethod: PaymentInfo.paymentMethodForPayment(payment, false),
-            paymentToken: payment.isToken
-                ? PaymentInfo.knownToken(payment.currency, cometWithdraw.chainId).token
-                : PaymentInfo.NON_TOKEN_PAYMENT,
-            paymentTokenSymbol: payment.currency,
-            paymentMaxCost: payment.isToken ? PaymentInfo.findMaxCost(payment, cometWithdraw.chainId) : 0,
             nonceSecret: accountSecret.nonceSecret,
             totalPlays: 1
         });
@@ -1108,12 +1080,8 @@ library Actions {
             quarkAccount: transfer.sender,
             actionType: ACTION_TYPE_TRANSFER,
             actionContext: abi.encode(transferActionContext),
+            quotePayActionContext: "",
             paymentMethod: PaymentInfo.paymentMethodForPayment(payment, useQuotecall),
-            paymentToken: payment.isToken
-                ? PaymentInfo.knownToken(payment.currency, transfer.chainId).token
-                : PaymentInfo.NON_TOKEN_PAYMENT,
-            paymentTokenSymbol: payment.currency,
-            paymentMaxCost: payment.isToken ? PaymentInfo.findMaxCost(payment, transfer.chainId) : 0,
             nonceSecret: accountSecret.nonceSecret,
             totalPlays: 1
         });
@@ -1179,12 +1147,8 @@ library Actions {
             quarkAccount: borrowInput.borrower,
             actionType: ACTION_TYPE_MORPHO_BORROW,
             actionContext: abi.encode(borrowActionContext),
+            quotePayActionContext: "",
             paymentMethod: PaymentInfo.paymentMethodForPayment(payment, false),
-            paymentToken: payment.isToken
-                ? PaymentInfo.knownToken(payment.currency, borrowInput.chainId).token
-                : PaymentInfo.NON_TOKEN_PAYMENT,
-            paymentTokenSymbol: payment.currency,
-            paymentMaxCost: payment.isToken ? PaymentInfo.findMaxCost(payment, borrowInput.chainId) : 0,
             nonceSecret: accountSecret.nonceSecret,
             totalPlays: 1
         });
@@ -1250,12 +1214,8 @@ library Actions {
             quarkAccount: repayInput.repayer,
             actionType: ACTION_TYPE_MORPHO_REPAY,
             actionContext: abi.encode(morphoRepayActionContext),
+            quotePayActionContext: "",
             paymentMethod: PaymentInfo.paymentMethodForPayment(payment, false),
-            paymentToken: payment.isToken
-                ? PaymentInfo.knownToken(payment.currency, repayInput.chainId).token
-                : PaymentInfo.NON_TOKEN_PAYMENT,
-            paymentTokenSymbol: payment.currency,
-            paymentMaxCost: payment.isToken ? PaymentInfo.findMaxCost(payment, repayInput.chainId) : 0,
             nonceSecret: accountSecret.nonceSecret,
             totalPlays: 1
         });
@@ -1311,11 +1271,8 @@ library Actions {
             quarkAccount: vaultSupply.sender,
             actionType: ACTION_TYPE_MORPHO_VAULT_SUPPLY,
             actionContext: abi.encode(vaultSupplyActionContext),
+            quotePayActionContext: "",
             paymentMethod: PaymentInfo.paymentMethodForPayment(payment, useQuotecall),
-            // Null address for OFFCHAIN payment.
-            paymentToken: payment.isToken ? PaymentInfo.knownToken(payment.currency, vaultSupply.chainId).token : address(0),
-            paymentTokenSymbol: payment.currency,
-            paymentMaxCost: payment.isToken ? PaymentInfo.findMaxCost(payment, vaultSupply.chainId) : 0,
             nonceSecret: accountSecret.nonceSecret,
             totalPlays: 1
         });
@@ -1371,13 +1328,8 @@ library Actions {
             quarkAccount: vaultWithdraw.withdrawer,
             actionType: ACTION_TYPE_MORPHO_VAULT_WITHDRAW,
             actionContext: abi.encode(vaultWithdrawActionContext),
+            quotePayActionContext: "",
             paymentMethod: PaymentInfo.paymentMethodForPayment(payment, false),
-            // Null address for OFFCHAIN payment.
-            paymentToken: payment.isToken
-                ? PaymentInfo.knownToken(payment.currency, vaultWithdraw.chainId).token
-                : address(0),
-            paymentTokenSymbol: payment.currency,
-            paymentMaxCost: payment.isToken ? PaymentInfo.findMaxCost(payment, vaultWithdraw.chainId) : 0,
             nonceSecret: accountSecret.nonceSecret,
             totalPlays: 1
         });
@@ -1441,13 +1393,8 @@ library Actions {
             quarkAccount: claimRewards.claimer,
             actionType: ACTION_TYPE_MORPHO_CLAIM_REWARDS,
             actionContext: abi.encode(claimRewardsActionContext),
+            quotePayActionContext: "",
             paymentMethod: PaymentInfo.paymentMethodForPayment(payment, false),
-            // Null address for OFFCHAIN payment.
-            paymentToken: payment.isToken
-                ? PaymentInfo.knownToken(payment.currency, claimRewards.chainId).token
-                : address(0),
-            paymentTokenSymbol: payment.currency,
-            paymentMaxCost: payment.isToken ? PaymentInfo.findMaxCost(payment, claimRewards.chainId) : 0,
             nonceSecret: accountSecret.nonceSecret,
             totalPlays: 1
         });
@@ -1492,7 +1439,7 @@ library Actions {
             assetSymbol: assetPositions.symbol,
             chainId: quotePayInfo.chainId,
             quoteId: payment.quoteId,
-            payee: quotePayInfo.sender
+            payee: QUOTE_PAY_RECIPIENT
         });
 
         Action memory action = Actions.Action({
@@ -1500,13 +1447,9 @@ library Actions {
             quarkAccount: quotePayInfo.sender,
             actionType: ACTION_TYPE_QUOTE_PAY,
             actionContext: abi.encode(quotePayActionContext),
+            quotePayActionContext: abi.encode(quotePayActionContext),
             // TODO: Update this (paymentMethodForPayment)
             paymentMethod: PaymentInfo.paymentMethodForPayment(payment, true),
-            paymentToken: payment.isToken
-                ? PaymentInfo.knownToken(payment.currency, quotePayInfo.chainId).token
-                : PaymentInfo.NON_TOKEN_PAYMENT,
-            paymentTokenSymbol: payment.currency,
-            paymentMaxCost: payment.isToken ? PaymentInfo.findMaxCost(payment, quotePayInfo.chainId) : 0,
             nonceSecret: accountSecret.nonceSecret,
             totalPlays: 1
         });
@@ -1557,12 +1500,8 @@ library Actions {
                 ? ACTION_TYPE_UNWRAP
                 : ACTION_TYPE_WRAP,
             actionContext: abi.encode(wrapOrUnwrapActionContext),
+            quotePayActionContext: "",
             paymentMethod: PaymentInfo.paymentMethodForPayment(payment, useQuotecall),
-            paymentToken: payment.isToken
-                ? PaymentInfo.knownToken(payment.currency, wrapOrUnwrap.chainId).token
-                : PaymentInfo.NON_TOKEN_PAYMENT,
-            paymentTokenSymbol: payment.currency,
-            paymentMaxCost: payment.isToken ? PaymentInfo.findMaxCost(payment, wrapOrUnwrap.chainId) : 0,
             nonceSecret: accountSecret.nonceSecret,
             totalPlays: 1
         });
@@ -1578,18 +1517,41 @@ library Actions {
         bytes[] memory scriptSources = new bytes[](1);
         scriptSources[0] = type(ApproveAndSwap).creationCode;
 
-        Accounts.ChainAccounts memory accounts = Accounts.findChainAccounts(swap.chainId, swap.chainAccountsList);
+        Accounts.QuarkSecret memory accountSecret;
+        SwapActionContext memory swapActionContext;
+        // Local scope to avoid stack too deep
+        {
+            Accounts.ChainAccounts memory accounts = Accounts.findChainAccounts(swap.chainId, swap.chainAccountsList);
 
-        Accounts.AssetPositions memory sellTokenAssetPositions =
-            Accounts.findAssetPositions(swap.sellAssetSymbol, accounts.assetPositionsList);
+            Accounts.AssetPositions memory sellTokenAssetPositions =
+                Accounts.findAssetPositions(swap.sellAssetSymbol, accounts.assetPositionsList);
 
-        Accounts.AssetPositions memory buyTokenAssetPositions =
-            Accounts.findAssetPositions(swap.buyAssetSymbol, accounts.assetPositionsList);
+            Accounts.AssetPositions memory buyTokenAssetPositions =
+                Accounts.findAssetPositions(swap.buyAssetSymbol, accounts.assetPositionsList);
 
-        Accounts.AssetPositions memory feeTokenAssetPositions =
-            Accounts.findAssetPositions(swap.feeAssetSymbol, accounts.assetPositionsList);
+            Accounts.AssetPositions memory feeTokenAssetPositions =
+                Accounts.findAssetPositions(swap.feeAssetSymbol, accounts.assetPositionsList);
 
-        Accounts.QuarkSecret memory accountSecret = Accounts.findQuarkSecret(swap.sender, accounts.quarkSecrets);
+            accountSecret = Accounts.findQuarkSecret(swap.sender, accounts.quarkSecrets);
+
+            // Construct Action
+            swapActionContext = SwapActionContext({
+                chainId: swap.chainId,
+                feeAmount: swap.feeAmount,
+                feeAssetSymbol: swap.feeAssetSymbol,
+                feeToken: swap.feeToken,
+                feeTokenPrice: feeTokenAssetPositions.usdPrice,
+                inputAmount: swap.sellAmount,
+                inputAssetSymbol: swap.sellAssetSymbol,
+                inputToken: swap.sellToken,
+                inputTokenPrice: sellTokenAssetPositions.usdPrice,
+                outputAmount: swap.buyAmount,
+                outputAssetSymbol: swap.buyAssetSymbol,
+                outputToken: swap.buyToken,
+                outputTokenPrice: buyTokenAssetPositions.usdPrice,
+                isExactOut: swap.isExactOut
+            });
+        }
 
         // TODO: Handle wrapping ETH? Do we need to?
         bytes memory scriptCalldata = abi.encodeWithSelector(
@@ -1612,35 +1574,13 @@ library Actions {
             expiry: swap.blockTimestamp + SWAP_EXPIRY_BUFFER
         });
 
-        // Construct Action
-        SwapActionContext memory swapActionContext = SwapActionContext({
-            chainId: swap.chainId,
-            feeAmount: swap.feeAmount,
-            feeAssetSymbol: swap.feeAssetSymbol,
-            feeToken: swap.feeToken,
-            feeTokenPrice: feeTokenAssetPositions.usdPrice,
-            inputAmount: swap.sellAmount,
-            inputAssetSymbol: swap.sellAssetSymbol,
-            inputToken: swap.sellToken,
-            inputTokenPrice: sellTokenAssetPositions.usdPrice,
-            outputAmount: swap.buyAmount,
-            outputAssetSymbol: swap.buyAssetSymbol,
-            outputToken: swap.buyToken,
-            outputTokenPrice: buyTokenAssetPositions.usdPrice,
-            isExactOut: swap.isExactOut
-        });
-
         Action memory action = Actions.Action({
             chainId: swap.chainId,
             quarkAccount: swap.sender,
             actionType: ACTION_TYPE_SWAP,
             actionContext: abi.encode(swapActionContext),
+            quotePayActionContext: "",
             paymentMethod: PaymentInfo.paymentMethodForPayment(payment, useQuotecall),
-            paymentToken: payment.isToken
-                ? PaymentInfo.knownToken(payment.currency, swap.chainId).token
-                : PaymentInfo.NON_TOKEN_PAYMENT,
-            paymentTokenSymbol: payment.currency,
-            paymentMaxCost: payment.isToken ? PaymentInfo.findMaxCost(payment, swap.chainId) : 0,
             nonceSecret: accountSecret.nonceSecret,
             totalPlays: 1
         });
@@ -1740,11 +1680,8 @@ library Actions {
             quarkAccount: swap.sender,
             actionType: ACTION_TYPE_RECURRING_SWAP,
             actionContext: abi.encode(recurringSwapActionContext),
+            quotePayActionContext: "",
             paymentMethod: PaymentInfo.paymentMethodForPayment(payment, useQuotecall),
-            // Null address for OFFCHAIN payment.
-            paymentToken: payment.isToken ? PaymentInfo.knownToken(payment.currency, swap.chainId).token : address(0),
-            paymentTokenSymbol: payment.currency,
-            paymentMaxCost: payment.isToken ? PaymentInfo.findMaxCost(payment, swap.chainId) : 0,
             nonceSecret: localVars.accountSecret.nonceSecret,
             totalPlays: RECURRING_SWAP_TOTAL_PLAYS
         });
@@ -1897,5 +1834,10 @@ library Actions {
     function emptyMorphoVaultWithdrawActionContext() external pure returns (MorphoVaultWithdrawActionContext memory) {
         MorphoVaultWithdrawActionContext[] memory mw = new MorphoVaultWithdrawActionContext[](1);
         return mw[0];
+    }
+
+    function emptyQuotePayActionContext() external pure returns (QuotePayActionContext memory) {
+        QuotePayActionContext[] memory qp = new QuotePayActionContext[](1);
+        return qp[0];
     }
 }

--- a/test/builder/BridgingLogic.t.sol
+++ b/test/builder/BridgingLogic.t.sol
@@ -156,8 +156,6 @@ contract BridgingLogicTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -182,8 +180,6 @@ contract BridgingLogicTest is Test, QuarkBuilderTest {
         assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
         assertEq(result.actions[1].actionType, "TRANSFER", "action type is 'TRANSFER'");
         assertEq(result.actions[1].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[1].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[1].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -315,8 +311,6 @@ contract BridgingLogicTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -340,8 +334,7 @@ contract BridgingLogicTest is Test, QuarkBuilderTest {
         assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
         assertEq(result.actions[1].actionType, "TRANSFER", "action type is 'TRANSFER'");
         assertEq(result.actions[1].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[1].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[1].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
+
         assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
         assertEq(

--- a/test/builder/QuarkBuilderCometBorrow.t.sol
+++ b/test/builder/QuarkBuilderCometBorrow.t.sol
@@ -166,8 +166,6 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BORROW", "action type is 'BORROW'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, chainPortfolios[0].nonceSecret, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
 
@@ -291,8 +289,6 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BORROW", "action type is 'BORROW'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, chainPortfolios[0].nonceSecret, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -428,8 +424,6 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BORROW", "action type is 'BORROW'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_8453, "payment token is USDC on Base");
-        assertEq(result.actions[0].paymentMaxCost, 1e6, "payment should have max cost of 1e6");
         assertEq(result.actions[0].nonceSecret, chainPortfolios[1].nonceSecret, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         uint256[] memory collateralTokenPrices = new uint256[](1);
@@ -453,14 +447,13 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
             ),
             "action context encoded from BorrowActionContext"
         );
+        assertEq(result.actions[0].quotePayActionContext, "", "no QuotePay action context");
 
         // second action
         assertEq(result.actions[1].chainId, 1, "operation is on chainid 1");
         assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[1].actionType, "QUOTE_PAY", "action type is 'QUOTE_PAY'");
         assertEq(result.actions[1].paymentMethod, "QUOTE_CALL", "payment method is 'QUOTE_CALL'");
-        assertEq(result.actions[1].paymentToken, USDC_1, "payment token is USDC on mainnet");
-        assertEq(result.actions[1].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
         assertEq(result.actions[1].nonceSecret, chainPortfolios[0].nonceSecret, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -472,7 +465,22 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
                     chainId: 1,
                     price: USDC_PRICE,
                     token: USDC_1,
-                    payee: address(0xa11ce),
+                    payee: Actions.QUOTE_PAY_RECIPIENT,
+                    quoteId: QUOTE_ID
+                })
+            ),
+            "action context encoded from QuotePayActionContext"
+        );
+        assertEq(
+            result.actions[1].quotePayActionContext,
+            abi.encode(
+                Actions.QuotePayActionContext({
+                    amount: 1.1e6,
+                    assetSymbol: "USDC",
+                    chainId: 1,
+                    price: USDC_PRICE,
+                    token: USDC_1,
+                    payee: Actions.QUOTE_PAY_RECIPIENT,
                     quoteId: QUOTE_ID
                 })
             ),
@@ -585,8 +593,6 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BORROW", "action type is 'BORROW'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 1.5e6, "payment max is set to 1.5e6 in this test case");
         assertEq(result.actions[0].nonceSecret, chainPortfolios[0].nonceSecret, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
 
@@ -750,8 +756,6 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
         assertEq(result.actions[0].nonceSecret, chainPortfolios[0].nonceSecret, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -776,8 +780,6 @@ contract QuarkBuilderCometBorrowTest is Test, QuarkBuilderTest {
         assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[1].actionType, "BORROW", "action type is 'BORROW'");
         assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
-        assertEq(result.actions[1].paymentMaxCost, 0.2e6, "payment should have max cost of 0.2e6");
         assertEq(result.actions[1].nonceSecret, chainPortfolios[1].nonceSecret, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
 

--- a/test/builder/QuarkBuilderCometRepay.t.sol
+++ b/test/builder/QuarkBuilderCometRepay.t.sol
@@ -193,8 +193,6 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "REPAY", "action type is 'REPAY'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, chainPortfolios[0].nonceSecret, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
 
@@ -320,8 +318,6 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "REPAY", "action type is 'REPAY'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, chainPortfolios[0].nonceSecret, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -454,8 +450,6 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "REPAY", "action type is 'REPAY'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 0.5e6, "payment max is set to .5e6 in this test case");
         assertEq(result.actions[0].nonceSecret, chainPortfolios[0].nonceSecret, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
 
@@ -617,8 +611,6 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
         assertEq(result.actions[0].nonceSecret, chainPortfolios[0].nonceSecret, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -643,8 +635,6 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[1].actionType, "REPAY", "action type is 'REPAY'");
         assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
-        assertEq(result.actions[1].paymentMaxCost, 0.2e6, "payment should have max cost of 0.2e6");
         assertEq(result.actions[1].nonceSecret, chainPortfolios[1].nonceSecret, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
 
@@ -769,8 +759,6 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "REPAY", "action type is 'REPAY'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
         assertEq(result.actions[0].nonceSecret, chainPortfolios[0].nonceSecret, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
 
@@ -793,6 +781,21 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
                 })
             ),
             "action context encoded from RepayActionContext"
+        );
+        assertEq(
+            result.actions[0].quotePayActionContext,
+            abi.encode(
+                Actions.QuotePayActionContext({
+                    amount: 0.1e6,
+                    assetSymbol: "USDC",
+                    chainId: 1,
+                    price: USDC_PRICE,
+                    token: USDC_1,
+                    payee: Actions.QUOTE_PAY_RECIPIENT,
+                    quoteId: QUOTE_ID
+                })
+            ),
+            "action context encoded from QuotePayActionContext"
         );
 
         // TODO: Check the contents of the EIP712 data
@@ -934,8 +937,6 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
         assertEq(result.actions[0].nonceSecret, chainPortfolios[0].nonceSecret, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -961,8 +962,6 @@ contract QuarkBuilderCometRepayTest is Test, QuarkBuilderTest {
         assertEq(result.actions[1].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[1].actionType, "REPAY", "action type is 'REPAY'");
         assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
-        assertEq(result.actions[1].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
         assertEq(result.actions[1].nonceSecret, chainPortfolios[1].nonceSecret, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
 

--- a/test/builder/QuarkBuilderCometSupply.t.sol
+++ b/test/builder/QuarkBuilderCometSupply.t.sol
@@ -141,8 +141,6 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "SUPPLY", "action type is 'SUPPLY'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -225,8 +223,6 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "SUPPLY", "action type is 'SUPPLY'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -325,8 +321,6 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "SUPPLY", "action type is 'SUPPLY'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -401,8 +395,6 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "SUPPLY", "action type is 'SUPPLY'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment max is set to .1e6 in this test case");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -418,6 +410,21 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
                 })
             ),
             "action context encoded from SupplyActionContext"
+        );
+        assertEq(
+            result.actions[0].quotePayActionContext,
+            abi.encode(
+                Actions.QuotePayActionContext({
+                    amount: 0.1e6,
+                    assetSymbol: "USDC",
+                    chainId: 1,
+                    price: USDC_PRICE,
+                    token: USDC_1,
+                    payee: Actions.QUOTE_PAY_RECIPIENT,
+                    quoteId: QUOTE_ID
+                })
+            ),
+            "action context encoded from QuotePayActionContext"
         );
 
         // TODO: Check the contents of the EIP712 data
@@ -520,8 +527,6 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -547,8 +552,6 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
         assertEq(result.actions[1].actionType, "SUPPLY", "action type is 'SUPPLY'");
         assertEq(result.actions[1].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[1].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[1].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -665,8 +668,6 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -692,8 +693,6 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
         assertEq(result.actions[1].actionType, "SUPPLY", "action type is 'SUPPLY'");
         assertEq(result.actions[1].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[1].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[1].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -796,8 +795,6 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "QUOTE_CALL", "payment method is 'QUOTE_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-        assertEq(result.actions[0].paymentMaxCost, 0.5e6, "payment should have max cost of 0.5e6");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -822,8 +819,6 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
         assertEq(result.actions[1].actionType, "SUPPLY", "action type is 'SUPPLY'");
         assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
-        assertEq(result.actions[1].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
         assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -926,8 +921,6 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-        assertEq(result.actions[0].paymentMaxCost, 0.5e6, "payment should have max cost of 0.5e6");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -952,8 +945,6 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
         assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
         assertEq(result.actions[1].actionType, "SUPPLY", "action type is 'SUPPLY'");
         assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
-        assertEq(result.actions[1].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
         assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
         assertEq(

--- a/test/builder/QuarkBuilderCometWithdraw.t.sol
+++ b/test/builder/QuarkBuilderCometWithdraw.t.sol
@@ -98,8 +98,6 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "WITHDRAW", "action type is 'WITHDRAW'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -170,8 +168,6 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "WITHDRAW", "action type is 'WITHDRAW'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment max is set to .1e6 in this test case");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -187,6 +183,21 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
                 })
             ),
             "action context encoded from WithdrawActionContext"
+        );
+        assertEq(
+            result.actions[0].quotePayActionContext,
+            abi.encode(
+                Actions.QuotePayActionContext({
+                    amount: 0.1e6,
+                    assetSymbol: "USDC",
+                    chainId: 1,
+                    price: USDC_PRICE,
+                    token: USDC_1,
+                    payee: Actions.QUOTE_PAY_RECIPIENT,
+                    quoteId: QUOTE_ID
+                })
+            ),
+            "action context encoded from QuotePayActionContext"
         );
 
         // TODO: Check the contents of the EIP712 data
@@ -242,8 +253,6 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "WITHDRAW", "action type is 'WITHDRAW'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 0.5e6, "payment max is set to .1e6 in this test case");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -337,8 +346,6 @@ contract QuarkBuilderCometWithdrawTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "WITHDRAW", "action type is 'WITHDRAW'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment max is set to 0.1e6");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(

--- a/test/builder/QuarkBuilderMorphoBorrow.t.sol
+++ b/test/builder/QuarkBuilderMorphoBorrow.t.sol
@@ -158,8 +158,6 @@ contract QuarkBuilderMorphoBorrowTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "MORPHO_BORROW", "action type is 'MORPHO_BORROW'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -262,8 +260,6 @@ contract QuarkBuilderMorphoBorrowTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "MORPHO_BORROW", "action type is 'MORPHO_BORROW'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -368,8 +364,6 @@ contract QuarkBuilderMorphoBorrowTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "MORPHO_BORROW", "action type is 'MORPHO_BORROW'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment max is set to .1e6 in this test case");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -390,6 +384,21 @@ contract QuarkBuilderMorphoBorrowTest is Test, QuarkBuilderTest {
                 })
             ),
             "action context encoded from MorphoBorrowActionContext"
+        );
+        assertEq(
+            result.actions[0].quotePayActionContext,
+            abi.encode(
+                Actions.QuotePayActionContext({
+                    amount: 0.1e6,
+                    assetSymbol: "USDC",
+                    chainId: 1,
+                    price: USDC_PRICE,
+                    token: USDC_1,
+                    payee: Actions.QUOTE_PAY_RECIPIENT,
+                    quoteId: QUOTE_ID
+                })
+            ),
+            "action context encoded from QuotePayActionContext"
         );
 
         assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
@@ -474,8 +483,6 @@ contract QuarkBuilderMorphoBorrowTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "MORPHO_BORROW", "action type is 'MORPHO_MORPHO_BORROW'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment max is set to .1e6 in this test case");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(

--- a/test/builder/QuarkBuilderMorphoClaimRewards.t.sol
+++ b/test/builder/QuarkBuilderMorphoClaimRewards.t.sol
@@ -117,8 +117,6 @@ contract QuarkBuilderMorphoClaimRewardsTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "MORPHO_CLAIM_REWARDS", "action type is 'MORPHO_CLAIM_REWARDS'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
 
@@ -209,8 +207,6 @@ contract QuarkBuilderMorphoClaimRewardsTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "MORPHO_CLAIM_REWARDS", "action type is 'MORPHO_CLAIM_REWARDS'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 1e6, "payment max is set to .1e6 in this test case");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
 

--- a/test/builder/QuarkBuilderMorphoRepay.t.sol
+++ b/test/builder/QuarkBuilderMorphoRepay.t.sol
@@ -162,8 +162,6 @@ contract QuarkBuilderMorphoRepayTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "MORPHO_REPAY", "action type is 'MORPHO_REPAY'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -273,8 +271,6 @@ contract QuarkBuilderMorphoRepayTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "MORPHO_REPAY", "action type is 'MORPHO_REPAY'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -385,8 +381,6 @@ contract QuarkBuilderMorphoRepayTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "MORPHO_REPAY", "action type is 'MORPHO_REPAY'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment max is set to .1e6 in this test case");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
 
@@ -417,6 +411,21 @@ contract QuarkBuilderMorphoRepayTest is Test, QuarkBuilderTest {
                 })
             ),
             "action context encoded from MorphoRepayActionContext"
+        );
+        assertEq(
+            result.actions[0].quotePayActionContext,
+            abi.encode(
+                Actions.QuotePayActionContext({
+                    amount: 0.1e6,
+                    assetSymbol: "USDC",
+                    chainId: 1,
+                    price: USDC_PRICE,
+                    token: USDC_1,
+                    payee: Actions.QUOTE_PAY_RECIPIENT,
+                    quoteId: QUOTE_ID
+                })
+            ),
+            "action context encoded from QuotePayActionContext"
         );
 
         assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
@@ -540,8 +549,6 @@ contract QuarkBuilderMorphoRepayTest is Test, QuarkBuilderTest {
     //     assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
     //     assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
     //     assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-    //     assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-    //     assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
     //     assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
     //     assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
     //     assertEq(
@@ -566,8 +573,6 @@ contract QuarkBuilderMorphoRepayTest is Test, QuarkBuilderTest {
     //     assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
     //     assertEq(result.actions[1].actionType, "MORPHO_REPAY", "action type is 'MORPHO_REPAY'");
     //     assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-    //     assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
-    //     assertEq(result.actions[1].paymentMaxCost, 0.2e6, "payment should have max cost of 0.2e6");
     //     assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
     //     assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
     //     assertEq(
@@ -679,8 +684,6 @@ contract QuarkBuilderMorphoRepayTest is Test, QuarkBuilderTest {
     //     assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
     //     assertEq(result.actions[0].actionType, "MORPHO_REPAY", "action type is 'MORPHO_REPAY'");
     //     assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-    //     assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-    //     assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
     //     assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
     //     assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
     //     assertEq(
@@ -834,8 +837,6 @@ contract QuarkBuilderMorphoRepayTest is Test, QuarkBuilderTest {
     //     assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
     //     assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
     //     assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-    //     assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-    //     assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
     //     assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
     //     assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
     //     assertEq(
@@ -861,8 +862,6 @@ contract QuarkBuilderMorphoRepayTest is Test, QuarkBuilderTest {
     //     assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
     //     assertEq(result.actions[1].actionType, "MORPHO_REPAY", "action type is 'MORPHO_REPAY'");
     //     assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-    //     assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
-    //     assertEq(result.actions[1].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
     //     assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
     //     assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
     //     assertEq(

--- a/test/builder/QuarkBuilderMorphoVaultSupply.t.sol
+++ b/test/builder/QuarkBuilderMorphoVaultSupply.t.sol
@@ -162,8 +162,6 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "MORPHO_VAULT_SUPPLY", "action type is 'MORPHO_VAULT_SUPPLY'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -238,8 +236,6 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "MORPHO_VAULT_SUPPLY", "action type is 'MORPHO_VAULT_SUPPLY'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -338,8 +334,6 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "MORPHO_VAULT_SUPPLY", "action type is 'MORPHO_VAULT_SUPPLY'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -412,8 +406,6 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "MORPHO_VAULT_SUPPLY", "action type is 'MORPHO_VAULT_SUPPLY'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment max is set to .1e6 in this test case");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -429,6 +421,21 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
                 })
             ),
             "action context encoded from SupplyActionContext"
+        );
+        assertEq(
+            result.actions[0].quotePayActionContext,
+            abi.encode(
+                Actions.QuotePayActionContext({
+                    amount: 0.1e6,
+                    assetSymbol: "USDC",
+                    chainId: 1,
+                    price: USDC_PRICE,
+                    token: USDC_1,
+                    payee: Actions.QUOTE_PAY_RECIPIENT,
+                    quoteId: QUOTE_ID
+                })
+            ),
+            "action context encoded from QuotePayActionContext"
         );
 
         // TODO: Check the contents of the EIP712 data
@@ -501,8 +508,6 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -528,8 +533,6 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
         assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
         assertEq(result.actions[1].actionType, "MORPHO_VAULT_SUPPLY", "action type is 'MORPHO_VAULT_SUPPLY'");
         assertEq(result.actions[1].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[1].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[1].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -617,8 +620,6 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -644,8 +645,6 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
         assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
         assertEq(result.actions[1].actionType, "MORPHO_VAULT_SUPPLY", "action type is 'MORPHO_VAULT_SUPPLY'");
         assertEq(result.actions[1].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[1].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[1].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -744,8 +743,6 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "QUOTE_CALL", "payment method is 'QUOTE_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-        assertEq(result.actions[0].paymentMaxCost, 0.5e6, "payment should have max cost of 0.5e6");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -770,8 +767,6 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
         assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
         assertEq(result.actions[1].actionType, "MORPHO_VAULT_SUPPLY", "action type is 'MORPHO_VAULT_SUPPLY'");
         assertEq(result.actions[1].paymentMethod, "QUOTE_CALL", "payment method is 'QUOTE_CALL'");
-        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
-        assertEq(result.actions[1].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
         assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -870,8 +865,6 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-        assertEq(result.actions[0].paymentMaxCost, 0.5e6, "payment should have max cost of 0.5e6");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -896,8 +889,6 @@ contract QuarkBuilderMorphoVaultTest is Test, QuarkBuilderTest {
         assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
         assertEq(result.actions[1].actionType, "MORPHO_VAULT_SUPPLY", "action type is 'MORPHO_VAULT_SUPPLY'");
         assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
-        assertEq(result.actions[1].paymentMaxCost, 0.1e6, "payment should have max cost of 0.1e6");
         assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
         assertEq(

--- a/test/builder/QuarkBuilderMorphoVaultWithdraw.t.sol
+++ b/test/builder/QuarkBuilderMorphoVaultWithdraw.t.sol
@@ -82,8 +82,6 @@ contract QuarkBuilderMorphoVaultWithdrawTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "MORPHO_VAULT_WITHDRAW", "action type is 'MORPHO_VAULT_WITHDRAW'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -154,8 +152,6 @@ contract QuarkBuilderMorphoVaultWithdrawTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "MORPHO_VAULT_WITHDRAW", "action type is 'MORPHO_VAULT_WITHDRAW'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment max is set to .1e6 in this test case");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -171,6 +167,21 @@ contract QuarkBuilderMorphoVaultWithdrawTest is Test, QuarkBuilderTest {
                 })
             ),
             "action context encoded from WithdrawActionContext"
+        );
+        assertEq(
+            result.actions[0].quotePayActionContext,
+            abi.encode(
+                Actions.QuotePayActionContext({
+                    amount: 0.1e6,
+                    assetSymbol: "USDC",
+                    chainId: 1,
+                    price: USDC_PRICE,
+                    token: USDC_1,
+                    payee: Actions.QUOTE_PAY_RECIPIENT,
+                    quoteId: QUOTE_ID
+                })
+            ),
+            "action context encoded from QuotePayActionContext"
         );
 
         // TODO: Check the contents of the EIP712 data
@@ -226,8 +237,6 @@ contract QuarkBuilderMorphoVaultWithdrawTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "MORPHO_VAULT_WITHDRAW", "action type is 'MORPHO_VAULT_WITHDRAW'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 0.5e6, "payment max is set to .5e6 in this test case");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -320,8 +329,6 @@ contract QuarkBuilderMorphoVaultWithdrawTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "MORPHO_VAULT_WITHDRAW", "action type is 'MORPHO_VAULT_WITHDRAW'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 0.1e6, "payment max is set to 0.1e6");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(

--- a/test/builder/QuarkBuilderRecurringSwap.t.sol
+++ b/test/builder/QuarkBuilderRecurringSwap.t.sol
@@ -245,8 +245,6 @@ contract QuarkBuilderRecurringSwapTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce does the swap");
         assertEq(result.actions[0].actionType, "RECURRING_SWAP", "action type is 'RECURRING_SWAP'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, Actions.RECURRING_SWAP_TOTAL_PLAYS, "total plays is correct");
         assertEq(
@@ -336,8 +334,6 @@ contract QuarkBuilderRecurringSwapTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce does the swap");
         assertEq(result.actions[0].actionType, "RECURRING_SWAP", "action type is 'RECURRING_SWAP'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, Actions.RECURRING_SWAP_TOTAL_PLAYS, "total plays is correct");
         assertEq(
@@ -424,8 +420,6 @@ contract QuarkBuilderRecurringSwapTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce does the swap");
         assertEq(result.actions[0].actionType, "RECURRING_SWAP", "action type is 'RECURRING_SWAP'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 5e6, "payment max is set to 5e6 in this test case");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, Actions.RECURRING_SWAP_TOTAL_PLAYS, "total plays is correct");
         assertEq(

--- a/test/builder/QuarkBuilderSwap.t.sol
+++ b/test/builder/QuarkBuilderSwap.t.sol
@@ -188,8 +188,6 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce does the swap");
         assertEq(result.actions[0].actionType, "SWAP", "action type is 'SWAP'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -299,8 +297,6 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce does the swap");
         assertEq(result.actions[0].actionType, "SWAP", "action type is 'SWAP'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -380,8 +376,6 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce does the swap");
         assertEq(result.actions[0].actionType, "SWAP", "action type is 'SWAP'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 5e6, "payment max is set to 5e6 in this test case");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -405,6 +399,21 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                 })
             ),
             "action context encoded from SwapActionContext"
+        );
+        assertEq(
+            result.actions[0].quotePayActionContext,
+            abi.encode(
+                Actions.QuotePayActionContext({
+                    amount: 5e6,
+                    assetSymbol: "USDC",
+                    chainId: 1,
+                    price: USDC_PRICE,
+                    token: USDC_1,
+                    payee: Actions.QUOTE_PAY_RECIPIENT,
+                    quoteId: QUOTE_ID
+                })
+            ),
+            "action context encoded from QuotePayActionContext"
         );
 
         // TODO: Check the contents of the EIP712 data
@@ -487,8 +496,6 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce does the swap");
         assertEq(result.actions[0].actionType, "SWAP", "action type is 'SWAP'");
         assertEq(result.actions[0].paymentMethod, "QUOTE_CALL", "payment method is 'QUOTE_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 5e6, "payment max is set to 5e6 in this test case");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -611,8 +618,6 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -636,8 +641,6 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
         assertEq(result.actions[1].actionType, "SWAP", "action type is 'SWAP'");
         assertEq(result.actions[1].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[1].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[1].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -739,8 +742,6 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-        assertEq(result.actions[0].paymentMaxCost, 5e6, "payment should have max cost of 5e6");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -760,12 +761,26 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
             ),
             "action context encoded from BridgeActionContext"
         );
+        assertEq(
+            result.actions[0].quotePayActionContext,
+            abi.encode(
+                Actions.QuotePayActionContext({
+                    amount: 6e6,
+                    assetSymbol: "USDC",
+                    chainId: 1,
+                    price: USDC_PRICE,
+                    token: USDC_1,
+                    payee: Actions.QUOTE_PAY_RECIPIENT,
+                    quoteId: QUOTE_ID
+                })
+            ),
+            "action context encoded from QuotePayActionContext"
+        );
+
         assertEq(result.actions[1].chainId, 8453, "operation is on chainid 8453");
         assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
         assertEq(result.actions[1].actionType, "SWAP", "action type is 'SWAP'");
         assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
-        assertEq(result.actions[1].paymentMaxCost, 1e6, "payment should have max cost of 1e6");
         assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -790,6 +805,7 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
             ),
             "action context encoded from SwapActionContext"
         );
+        assertEq(result.actions[1].quotePayActionContext, "", "no QuotePay action context");
 
         // TODO: Check the contents of the EIP712 data
         assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");
@@ -867,8 +883,6 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "QUOTE_CALL", "payment method is 'QUOTE_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-        assertEq(result.actions[0].paymentMaxCost, 5e6, "payment should have max cost of 5e6");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -888,12 +902,26 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
             ),
             "action context encoded from BridgeActionContext"
         );
+        assertEq(
+            result.actions[0].quotePayActionContext,
+            abi.encode(
+                Actions.QuotePayActionContext({
+                    amount: 6e6,
+                    assetSymbol: "USDC",
+                    chainId: 1,
+                    price: USDC_PRICE,
+                    token: USDC_1,
+                    payee: Actions.QUOTE_PAY_RECIPIENT,
+                    quoteId: QUOTE_ID
+                })
+            ),
+            "action context encoded from QuotePayActionContext"
+        );
+
         assertEq(result.actions[1].chainId, 8453, "operation is on chainid 8453");
         assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
         assertEq(result.actions[1].actionType, "SWAP", "action type is 'SWAP'");
         assertEq(result.actions[1].paymentMethod, "QUOTE_CALL", "payment method is 'QUOTE_CALL'");
-        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
-        assertEq(result.actions[1].paymentMaxCost, 1e6, "payment should have max cost of 1e6");
         assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -918,6 +946,7 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
             ),
             "action context encoded from SwapActionContext"
         );
+        assertEq(result.actions[1].quotePayActionContext, "", "no QuotePay action context");
 
         // TODO: Check the contents of the EIP712 data
         assertNotEq(result.eip712Data.digest, hex"", "non-empty digest");

--- a/test/builder/QuarkBuilderTransfer.t.sol
+++ b/test/builder/QuarkBuilderTransfer.t.sol
@@ -225,8 +225,6 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "TRANSFER", "action type is 'TRANSFER'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -349,8 +347,6 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[0].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -374,8 +370,6 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
         assertEq(result.actions[1].actionType, "TRANSFER", "action type is 'TRANSFER'");
         assertEq(result.actions[1].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[1].paymentToken, address(0), "payment token is null");
-        assertEq(result.actions[1].paymentMaxCost, 0, "payment has no max cost, since 'OFFCHAIN'");
         assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -486,8 +480,6 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-        assertEq(result.actions[0].paymentMaxCost, 0.5e6, "payment should have max cost of 5e5");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -511,8 +503,6 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
         assertEq(result.actions[1].actionType, "TRANSFER", "action type is 'TRANSFER'");
         assertEq(result.actions[1].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
-        assertEq(result.actions[1].paymentMaxCost, 0.1e6, "payment should have max cost of 1e5");
         assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -528,6 +518,21 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                 })
             ),
             "action context encoded from TransferActionContext"
+        );
+        assertEq(
+            result.actions[0].quotePayActionContext,
+            abi.encode(
+                Actions.QuotePayActionContext({
+                    amount: 0.6e6,
+                    assetSymbol: "USDC",
+                    chainId: 1,
+                    price: USDC_PRICE,
+                    token: USDC_1,
+                    payee: Actions.QUOTE_PAY_RECIPIENT,
+                    quoteId: QUOTE_ID
+                })
+            ),
+            "action context encoded from QuotePayActionContext"
         );
 
         // TODO: Check the contents of the EIP712 data
@@ -596,8 +601,6 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "TRANSFER", "action type is 'TRANSFER'");
         assertEq(result.actions[0].paymentMethod, "QUOTE_CALL", "payment method is 'QUOTE_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
-        assertEq(result.actions[0].paymentMaxCost, 1e5, "payment max is set to 1e5 in this test case");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -726,8 +729,6 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "BRIDGE", "action type is 'BRIDGE'");
         assertEq(result.actions[0].paymentMethod, "QUOTE_CALL", "payment method is 'QUOTE_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC on mainnet");
-        assertEq(result.actions[0].paymentMaxCost, 0.5e6, "payment should have max cost of 5e5");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -751,8 +752,6 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(result.actions[1].quarkAccount, address(0xb0b), "0xb0b sends the funds");
         assertEq(result.actions[1].actionType, "TRANSFER", "action type is 'TRANSFER'");
         assertEq(result.actions[1].paymentMethod, "QUOTE_CALL", "payment method is 'QUOTE_CALL'");
-        assertEq(result.actions[1].paymentToken, USDC_8453, "payment token is USDC on Base");
-        assertEq(result.actions[1].paymentMaxCost, 0.1e6, "payment should have max cost of 1e5");
         assertEq(result.actions[1].nonceSecret, BOB_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[1].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -925,7 +924,6 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "TRANSFER", "action type is 'TRANSFER'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is USD");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -1034,7 +1032,6 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "TRANSFER", "action type is 'TRANSFER'");
         assertEq(result.actions[0].paymentMethod, "PAY_CALL", "payment method is 'PAY_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -1050,6 +1047,21 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                 })
             ),
             "action context encoded from TransferActionContext"
+        );
+        assertEq(
+            result.actions[0].quotePayActionContext,
+            abi.encode(
+                Actions.QuotePayActionContext({
+                    amount: 0.1e6,
+                    assetSymbol: "USDC",
+                    chainId: 1,
+                    price: USDC_PRICE,
+                    token: USDC_1,
+                    payee: Actions.QUOTE_PAY_RECIPIENT,
+                    quoteId: QUOTE_ID
+                })
+            ),
+            "action context encoded from QuotePayActionContext"
         );
 
         // TODO: Check the contents of the EIP712 data
@@ -1143,7 +1155,6 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "TRANSFER", "action type is 'TRANSFER'");
         assertEq(result.actions[0].paymentMethod, "QUOTE_CALL", "payment method is 'QUOTE_CALL'");
-        assertEq(result.actions[0].paymentToken, USDC_1, "payment token is USDC");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(
@@ -1250,7 +1261,6 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
         assertEq(result.actions[0].quarkAccount, address(0xa11ce), "0xa11ce sends the funds");
         assertEq(result.actions[0].actionType, "TRANSFER", "action type is 'TRANSFER'");
         assertEq(result.actions[0].paymentMethod, "OFFCHAIN", "payment method is 'OFFCHAIN'");
-        assertEq(result.actions[0].paymentToken, address(0), "payment token is USD");
         assertEq(result.actions[0].nonceSecret, ALICE_DEFAULT_SECRET, "unexpected nonce secret");
         assertEq(result.actions[0].totalPlays, 1, "total plays is 1");
         assertEq(


### PR DESCRIPTION
Adds `quotePayActionContext` to the `Action` struct so the client can know if a Quark Operation has a `QuotePay` attached to it. We also remove the following unneeded fields from `Action` to prevent stack too deep errors:
```
// Address of payment token on chainId.
// Null address if the payment method was OFFCHAIN.
address paymentToken;
string paymentTokenSymbol;
// TODO: might need to change this/remove this since payment isn't being made on each chain
uint256 paymentMaxCost;
```