### PR TITLE
Acceptance test for cross-chain action paid with WETH

### DIFF
--- a/test/Acceptance/Tests/AcceptanceTests/AcceptanceTests.swift
+++ b/test/Acceptance/Tests/AcceptanceTests/AcceptanceTests.swift
@@ -8,7 +8,7 @@ import Testing
 
 let allTests: [AcceptanceTest] = transferTests +
     cometBorrowTests +
-    cometSupplyTests + 
+    cometSupplyTests +
     cometRepayTests
 
 let tests = allTests.filter { !$0.skip }
@@ -16,7 +16,7 @@ let filteredTests = tests.contains { $0.only } ? tests.filter { $0.only } : test
 
 enum Call: CustomStringConvertible, Equatable {
     case bridge(
-        bridge: String, srcNetwork: Network, destinationNetwork: Network, tokenAmount: TokenAmount)
+        bridge: String, srcNetwork: Network, destinationNetwork: Network, inputTokenAmount: TokenAmount, outputTokenAmount: TokenAmount)
     case transferErc20(tokenAmount: TokenAmount, recipient: Account)
     case supplyToComet(tokenAmount: TokenAmount, market: Comet, network: Network)
     case supplyMultipleAssetsAndBorrowFromComet(
@@ -52,9 +52,9 @@ enum Call: CustomStringConvertible, Equatable {
                 _,
                 _,
                 inputToken,
-                _,
+                outputToken,
                 inputAmount,
-                _,
+                outputAmount,
                 destinationChainId,
                 _,
                 _,
@@ -67,10 +67,15 @@ enum Call: CustomStringConvertible, Equatable {
                     bridge: "Across",
                     srcNetwork: network,
                     destinationNetwork: Network.fromChainId(BigInt(destinationChainId)),
-                    tokenAmount: Token.getTokenAmount(
+                    inputTokenAmount: Token.getTokenAmount(
                         amount: inputAmount,
                         network: network,
                         address: inputToken
+                    ),
+                    outputTokenAmount: Token.getTokenAmount(
+                        amount: outputAmount,
+                        network: Network.fromChainId(BigInt(destinationChainId)),
+                        address: outputToken
                     )
                 )
             }
@@ -176,9 +181,9 @@ enum Call: CustomStringConvertible, Equatable {
 
     var description: String {
         switch self {
-        case let .bridge(bridge, chainId, destinationChainId, tokenAmount):
+        case let .bridge(bridge, chainId, destinationChainId, inputTokenAmount, outputTokenAmount):
             return
-                "bridge(\(bridge), \(tokenAmount.amount) \(tokenAmount.token.symbol) from \(chainId.description) to \(destinationChainId.description))"
+                "bridge(\(bridge), \(inputTokenAmount.amount) \(inputTokenAmount.token.symbol) to receive \(outputTokenAmount.amount) \(outputTokenAmount.token.symbol) from \(chainId.description) to \(destinationChainId.description))"
         case let .transferErc20(tokenAmount, recipient):
             return
                 "transferErc20(\(tokenAmount.amount) \(tokenAmount.token.symbol) to \(recipient.description))"

--- a/test/Acceptance/Tests/AcceptanceTests/CometBorrowTests.swift
+++ b/test/Acceptance/Tests/AcceptanceTests/CometBorrowTests.swift
@@ -185,7 +185,8 @@ let cometBorrowTests: [AcceptanceTest] = [
                         bridge: "Across",
                         srcNetwork: .ethereum,
                         destinationNetwork: .base,
-                        tokenAmount: .amt(2.2, .usdc)
+                        inputTokenAmount: .amt(2.2, .usdc),
+                        outputTokenAmount: .amt(1.178, .usdc)
                     ),
                     .quotePay(payment: .amt(0.3, .usdc), payee: .stax, quote: .basic),
                 ]),

--- a/test/Acceptance/Tests/AcceptanceTests/CometRepayTests.swift
+++ b/test/Acceptance/Tests/AcceptanceTests/CometRepayTests.swift
@@ -167,7 +167,7 @@ let cometRepayTests: [AcceptanceTest] = [
             )
         )
     ),
-    // @skip: QuarkBuilder reverts with `Panic` 
+    // @skip: QuarkBuilder reverts with `Panic`
     .init(
         name: "testCometRepayWithBridge",
         given: [
@@ -199,7 +199,8 @@ let cometRepayTests: [AcceptanceTest] = [
                         bridge: "Across",
                         srcNetwork: .ethereum,
                         destinationNetwork: .base,
-                        tokenAmount: .amt(2, .usdc)
+                        inputTokenAmount: .amt(2, .usdc),
+                        outputTokenAmount: .amt(0.98, .usdc)
                     ),
                     .quotePay(payment: .amt(0.3, .usdc), payee: .stax, quote: .basic),
                 ]),
@@ -213,7 +214,7 @@ let cometRepayTests: [AcceptanceTest] = [
         ),
         skip: true
     ),
-    // @skip: QuarkBuilder reverts with `Panic` 
+    // @skip: QuarkBuilder reverts with `Panic`
     .init(
         name: "testCometRepayMaxWithBridge",
         given: [
@@ -246,7 +247,8 @@ let cometRepayTests: [AcceptanceTest] = [
                         bridge: "Across",
                         srcNetwork: .ethereum,
                         destinationNetwork: .base,
-                        tokenAmount: .amt(10.01, .usdc)
+                        inputTokenAmount: .amt(10.01, .usdc),
+                        outputTokenAmount: .amt(8.9099, .usdc)
                     ),
                     .quotePay(payment: .amt(0.2, .usdc), payee: .stax, quote: .basic),
                 ]),

--- a/test/Acceptance/Tests/AcceptanceTests/TransferTests.swift
+++ b/test/Acceptance/Tests/AcceptanceTests/TransferTests.swift
@@ -83,7 +83,8 @@ let transferTests: [AcceptanceTest] = [
                     bridge: "Across",
                     srcNetwork: .base,
                     destinationNetwork: .arbitrum,
-                    tokenAmount: .amt(50, .usdc)
+                    inputTokenAmount: .amt(50, .usdc),
+                    outputTokenAmount: .amt(48.5, .usdc)
                 ),
                 .multicall([
                     .transferErc20(tokenAmount: .amt(98.44, .usdc), recipient: .bob),
@@ -155,11 +156,41 @@ let transferTests: [AcceptanceTest] = [
                         bridge: "Across",
                         srcNetwork: .base,
                         destinationNetwork: .arbitrum,
-                        tokenAmount: .amt(49.48, .usdc)
+                        inputTokenAmount: .amt(49.48, .usdc),
+                        outputTokenAmount: .amt(48.00, .usdc)
                     ),
                     .quotePay(payment: .amt(0.06, .usdc), payee: .stax, quote: .basic),
                 ]),
                 .transferErc20(tokenAmount: .amt(98, .usdc), recipient: .bob),
+            ])
+        )
+    ),
+    .init(
+        name: "Alice transfers WETH to Bob on Arbitrum via Across [Pay with WETH]",
+        given: [
+            .tokenBalance(.alice, .amt(0.5, .weth), .base),
+            .quote(.basic),
+            .acrossQuote(.amt(0.01, .weth), 0.01),
+        ],
+        when: .payWith(
+            currency: .weth,
+            .transfer(from: .alice, to: .bob, amount: .amt(0.3, .weth), on: .arbitrum)
+        ),
+        expect: .success(
+            .multi([
+                .multicall([
+                    .bridge(
+                        bridge: "Across",
+                        srcNetwork: .base,
+                        destinationNetwork: .arbitrum,
+                        inputTokenAmount: .amt(0.313, .weth),
+                        outputTokenAmount: .amt(0.3, .weth)
+                    ),
+                    // Total quote = 0.02 + 0.04 = 0.06
+                    // Amount in terms of ETH = 0.06 / 4000 = 0.000015
+                    .quotePay(payment: .amt(0.000015000000000037, .weth), payee: .stax, quote: .basic),
+                ]),
+                .transferErc20(tokenAmount: .amt(0.3, .weth), recipient: .bob),
             ])
         )
     ),


### PR DESCRIPTION
Adds an acceptance test for a cross-chain transfer that is paid with WETH. Our backend integration test currently fails for this case, so this is to ensure the QuarkBuilder logic is working properly.

I also separate out the `.bridge tokenAmount` into a `inputAmount` and `outputAmount` so we can test that bridge fees are properly accounted for.