### PR TITLE
Round up price payments

### DIFF
--- a/src/builder/Quotes.sol
+++ b/src/builder/Quotes.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.27;
 import {Accounts} from "src/builder/Accounts.sol";
 import {PaymentInfo} from "src/builder/PaymentInfo.sol";
 import {Strings} from "src/builder/Strings.sol";
+import {Math} from "src/lib/Math.sol";
 
 library Quotes {
     string public constant OP_TYPE_BASELINE = "BASELINE";
@@ -71,7 +72,8 @@ library Quotes {
 
             paymentMaxCosts[i] = PaymentInfo.PaymentMaxCost({
                 chainId: networkOperationFee.chainId,
-                amount: (networkOperationFee.price * (10 ** singularAssetPositionsForSymbol.decimals)) / assetQuote.price
+                amount: (networkOperationFee.price * (10 ** singularAssetPositionsForSymbol.decimals))
+                    / Math.subtractFlooredAtOne(assetQuote.price, 1)
             });
         }
 

--- a/src/lib/Math.sol
+++ b/src/lib/Math.sol
@@ -5,4 +5,8 @@ library Math {
     function subtractFlooredAtZero(uint256 a, uint256 b) internal pure returns (uint256) {
         return a > b ? a - b : 0;
     }
+
+    function subtractFlooredAtOne(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a > b ? a - b : 1;
+    }
 }

--- a/test/builder/QuarkBuilderCometSupply.t.sol
+++ b/test/builder/QuarkBuilderCometSupply.t.sol
@@ -102,7 +102,7 @@ contract QuarkBuilderCometSupplyTest is Test, QuarkBuilderTest {
                 0,
                 "IMPOSSIBLE_TO_CONSTRUCT",
                 "USDC",
-                1_000.03e6
+                1_000.03001e6
             )
         );
 

--- a/test/builder/QuarkBuilderMorphoClaimRewards.t.sol
+++ b/test/builder/QuarkBuilderMorphoClaimRewards.t.sol
@@ -262,7 +262,7 @@ contract QuarkBuilderMorphoClaimRewardsTest is Test, QuarkBuilderTest {
                 0,
                 "IMPOSSIBLE_TO_CONSTRUCT",
                 "USDC",
-                200e6
+                200.000002e6
             )
         );
         builder.morphoClaimRewards(

--- a/test/builder/QuarkBuilderMorphoVaultSupply.t.sol
+++ b/test/builder/QuarkBuilderMorphoVaultSupply.t.sol
@@ -84,7 +84,7 @@ contract QuarkBuilderMorphoVaultSupplyTest is Test, QuarkBuilderTest {
                 0,
                 "IMPOSSIBLE_TO_CONSTRUCT",
                 "USDC",
-                1_000.1e6
+                1_000.10001e6
             )
         );
         builder.morphoVaultSupply(

--- a/test/builder/QuarkBuilderRecurringSwap.t.sol
+++ b/test/builder/QuarkBuilderRecurringSwap.t.sol
@@ -139,7 +139,9 @@ contract QuarkBuilderRecurringSwapTest is Test, QuarkBuilderTest {
         networkOperationFees[0] =
             Quotes.NetworkOperationFee({opType: Quotes.OP_TYPE_BASELINE, chainId: 1, price: 1000e8});
 
-        vm.expectRevert(abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructPaycall.selector, "USDC", 1_000e6));
+        vm.expectRevert(
+            abi.encodeWithSelector(QuarkBuilderBase.UnableToConstructPaycall.selector, "USDC", 1_000.00001e6)
+        );
         builder.recurringSwap(
             buyWeth_({
                 chainId: 1,

--- a/test/builder/QuarkBuilderSwap.t.sol
+++ b/test/builder/QuarkBuilderSwap.t.sol
@@ -127,7 +127,7 @@ contract QuarkBuilderSwapTest is Test, QuarkBuilderTest {
                 0,
                 "IMPOSSIBLE_TO_CONSTRUCT",
                 "USDC",
-                1_000.1e6
+                1_000.10001e6
             )
         );
         builder.swap(

--- a/test/builder/QuarkBuilderTransfer.t.sol
+++ b/test/builder/QuarkBuilderTransfer.t.sol
@@ -136,7 +136,7 @@ contract QuarkBuilderTransferTest is Test, QuarkBuilderTest {
                 0,
                 "IMPOSSIBLE_TO_CONSTRUCT",
                 "USDC",
-                1_000.1e6
+                1_000.10001e6
             )
         );
         builder.transfer(


### PR DESCRIPTION
This patch rounds up for price payments, since the current math may beget a small underpay which would be rejected by the server.