### PR TITLE
delete --skip script from build-and-release workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -58,7 +58,7 @@ jobs:
             ${{ runner.os }}-foundry-out-
 
       - name: Build Artifacts
-        run: forge build --skip test --skip script
+        run: forge build --skip test
 
       - name: Extract Version Tag
         id: get_version


### PR DESCRIPTION
The `build-and-release` workflow seems to be hanging out to cached versions of source files; for example, the flow is here requesting a file that has been deleted:

![image](https://github.com/user-attachments/assets/14bfdddf-b7b9-417e-b921-44e64efeac73)

https://github.com/legend-hq/legend-scripts/actions/runs/13079698325/job/36500199239

Our suspicion is that the script files need to be re-built when creating a new release