### PR TITLE
Update Transfer Script to use send instead of call

### DIFF
--- a/src/DeFiScripts.sol
+++ b/src/DeFiScripts.sol
@@ -208,9 +208,9 @@ contract TransferActions is QuarkScript {
      * @param amount The amount to transfer
      */
     function transferNativeToken(address recipient, uint256 amount) external nonReentrant {
-        (bool success, bytes memory data) = payable(recipient).call{value: amount}("");
+        bool success = payable(recipient).send(amount);
         if (!success) {
-            revert DeFiScriptErrors.TransferFailed(data);
+            revert DeFiScriptErrors.TransferFailed();
         }
     }
 }

--- a/src/lib/DeFiScriptErrors.sol
+++ b/src/lib/DeFiScriptErrors.sol
@@ -8,7 +8,7 @@ pragma solidity 0.8.27;
  */
 library DeFiScriptErrors {
     error InvalidInput();
-    error TransferFailed(bytes data);
+    error TransferFailed();
     error ApproveAndSwapFailed(bytes data);
     error TooMuchSlippage(uint256 expectedBuyAmount, uint256 actualBuyAmount);
 }

--- a/test/TransferActions.t.sol
+++ b/test/TransferActions.t.sol
@@ -331,9 +331,7 @@ contract TransferActionsTest is Test {
                 Multicall.MulticallError.selector,
                 1,
                 callContracts[1],
-                abi.encodeWithSelector(
-                    DeFiScriptErrors.TransferFailed.selector, abi.encodeWithSelector(QuarkScript.ReentrantCall.selector)
-                )
+                abi.encodeWithSelector(DeFiScriptErrors.TransferFailed.selector)
             )
         );
         wallet.executeQuarkOperation(op, signature);
@@ -407,11 +405,7 @@ contract TransferActionsTest is Test {
         assertEq(address(wallet).balance, 10 ether);
         assertEq(address(evilReceiver).balance, 0 ether);
         // Reentering into the QuarkWallet fails due to there being no active callback
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                DeFiScriptErrors.TransferFailed.selector, abi.encodeWithSelector(QuarkWallet.NoActiveCallback.selector)
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(DeFiScriptErrors.TransferFailed.selector));
         vm.resumeGasMetering();
         wallet.executeQuarkOperation(op, signature);
         assertEq(address(wallet).balance, 10 ether);
@@ -439,14 +433,7 @@ contract TransferActionsTest is Test {
         assertEq(address(evilReceiver).balance, 0 ether);
         vm.resumeGasMetering();
         // Not replayable signature will blocked by QuarkWallet during executeQuarkOperation
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                DeFiScriptErrors.TransferFailed.selector,
-                abi.encodeWithSelector(
-                    QuarkNonceManager.NonReplayableNonce.selector, address(wallet), op.nonce, op.nonce
-                )
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(DeFiScriptErrors.TransferFailed.selector));
         wallet.executeQuarkOperation(op, signature);
         // assert on native ETH balance
         assertEq(address(wallet).balance, 10 ether);


### PR DESCRIPTION
With our current approach, it's possible to make _very_ expensive transactions. eg. https://basescan.org/tx/0x5c61f822b48ea45d80f040011c3f068bee4a3337341618b0f5fe2ba2e64af2bb consumes over 40 million gas, so the network fee is almost 100x the quote pay

To resolve this, instead of allowing sending ETH to contracts with logic in receive() or fallback(), we now just use `send` so Legend no longer cares about supporting contract logic on sending ETH