### PR TITLE
Loop and unloop long

### DIFF
--- a/src/LoopLong.sol
+++ b/src/LoopLong.sol
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.27;
+
+import {SafeERC20, IERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
+import {IUniswapV3SwapCallback} from "v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol";
+import {IUniswapV3Pool} from "v3-core/contracts/interfaces/IUniswapV3Pool.sol";
+import {SafeCast} from "v3-core/contracts/libraries/SafeCast.sol";
+
+import {QuarkScript} from "quark-core/src/QuarkScript.sol";
+
+import {PoolAddress} from "./vendor/uniswap-v3-periphery/PoolAddress.sol";
+import {UniswapFactoryAddress} from "./lib/UniswapFactoryAddress.sol";
+
+import {IMorpho, MarketParams, Position} from "src/interfaces/IMorpho.sol";
+
+/**
+ * @title Loop Long
+ * @notice Implements a looping long strategy on Morpho using Uniswap V3 flash swap as liquidity
+ * @author Legend Labs, Inc.
+ */
+contract LoopLong is IUniswapV3SwapCallback, QuarkScript {
+    using SafeERC20 for IERC20;
+    using SafeCast for uint256;
+
+    error InvalidCaller();
+    error SwapTooExpensive(address token, uint256 maxAmountIn, uint256 actualAmountIn);
+    error InvalidMarketParams();
+
+    event LoopExecuted(
+        address indexed sender,
+        address indexed exposureToken,
+        address indexed backingToken,
+        uint256 exposureAmount,
+        uint256 backingAmount
+    );
+
+    /// @dev The minimum value that can be returned from #getSqrtRatioAtTick. Equivalent to getSqrtRatioAtTick(MIN_TICK)
+    /// Reference: https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/TickMath.sol
+    uint160 internal constant MIN_SQRT_RATIO = 4295128739;
+    /// @dev The maximum value that can be returned from #getSqrtRatioAtTick. Equivalent to getSqrtRatioAtTick(MAX_TICK)
+    /// Reference: https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/TickMath.sol
+    uint160 internal constant MAX_SQRT_RATIO = 1461446703485210103287273052203988822378723970342;
+
+    /// @notice Stores details about the looping operation
+    struct LoopInfo {
+        address exposureToken;
+        address backingToken;
+        // Uniswap pool fee
+        uint24 poolFee;
+        // The amount of exposure tokens to add to the loop position
+        uint256 exposureAmount;
+        // Maximum amount of backing tokens that should be received for the exposure amount
+        uint256 maxSwapBackingAmount;
+        // Amount of backing tokens added to the loop position that is provided up front by user
+        uint256 initialBackingAmount;
+    }
+
+    /// @notice Input for loop long when interacting with the callback in a Uniswap V3 flash swap
+    struct LoopLongInput {
+        PoolAddress.PoolKey poolKey;
+        address morpho;
+        MarketParams morphoMarketParams;
+        LoopInfo loopInfo;
+    }
+
+    /**
+     * @notice Executes a looping long strategy via a flash swap (if necessary)
+     * @param morpho Address of the Morpho contract to interact with
+     * @param morphoMarketParams The parameters for the Morpho market to loop in
+     * @param loopInfo Information for executing the loop
+     */
+    function loop(address morpho, MarketParams memory morphoMarketParams, LoopInfo memory loopInfo) external {
+        allowCallback();
+
+        if (
+            (
+                morphoMarketParams.collateralToken != loopInfo.exposureToken
+                    || morphoMarketParams.loanToken != loopInfo.backingToken
+            )
+        ) {
+            revert InvalidMarketParams();
+        }
+        // When looping long, we swap (short) the backing token to long the exposure token
+        address tokenIn = loopInfo.backingToken;
+        address tokenOut = loopInfo.exposureToken;
+        uint256 amountOut = loopInfo.exposureAmount;
+
+        bool zeroForOne = tokenIn < tokenOut;
+        PoolAddress.PoolKey memory poolKey = PoolAddress.getPoolKey(tokenIn, tokenOut, loopInfo.poolFee);
+        if (amountOut > 0) {
+            IUniswapV3Pool(PoolAddress.computeAddress(UniswapFactoryAddress.getAddress(), poolKey)).swap(
+                address(this),
+                zeroForOne,
+                // Negative value for exact out
+                -amountOut.toInt256(),
+                zeroForOne ? MIN_SQRT_RATIO + 1 : MAX_SQRT_RATIO - 1,
+                abi.encode(
+                    LoopLongInput({
+                        poolKey: poolKey,
+                        loopInfo: loopInfo,
+                        morpho: morpho,
+                        morphoMarketParams: morphoMarketParams
+                    })
+                )
+            );
+        } else {
+            // No swap/callback necessary if the exposure amount is not being increased
+            adjustBackingTokenPosition({
+                repayAmount: loopInfo.initialBackingAmount,
+                borrowAmount: 0,
+                morpho: morpho,
+                morphoMarketParams: morphoMarketParams
+            });
+
+            emit LoopExecuted(
+                address(this),
+                loopInfo.exposureToken,
+                loopInfo.backingToken,
+                loopInfo.exposureAmount,
+                loopInfo.initialBackingAmount
+            );
+        }
+    }
+
+    /**
+     * @notice Callback function for Uniswap flash swap
+     * @param amount0Delta Amount of token0 owed (only need to repay positive value)
+     * @param amount1Delta Amount of token1 owed (only need to repay positive value)
+     * @param data Encoded LoopLongInput data passed from UniswapV3Pool.swap()
+     */
+    function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata data) external {
+        disallowCallback();
+
+        LoopLongInput memory input = abi.decode(data, (LoopLongInput));
+        LoopInfo memory loopInfo = input.loopInfo;
+        IUniswapV3Pool pool =
+            IUniswapV3Pool(PoolAddress.computeAddress(UniswapFactoryAddress.getAddress(), input.poolKey));
+        if (msg.sender != address(pool)) {
+            revert InvalidCaller();
+        }
+
+        uint256 backingTokensOwed = amount0Delta > 0 ? uint256(amount0Delta) : uint256(amount1Delta);
+        if (backingTokensOwed > loopInfo.maxSwapBackingAmount) {
+            revert SwapTooExpensive(loopInfo.backingToken, loopInfo.maxSwapBackingAmount, backingTokensOwed);
+        }
+
+        IERC20(input.morphoMarketParams.collateralToken).forceApprove(input.morpho, loopInfo.exposureAmount);
+        IMorpho(input.morpho).supplyCollateral({
+            marketParams: input.morphoMarketParams,
+            assets: loopInfo.exposureAmount,
+            onBehalf: address(this),
+            data: new bytes(0)
+        });
+        adjustBackingTokenPosition({
+            repayAmount: loopInfo.initialBackingAmount,
+            borrowAmount: backingTokensOwed,
+            morpho: input.morpho,
+            morphoMarketParams: input.morphoMarketParams
+        });
+
+        // Attempt to pay back amount owed after execution
+        IERC20(loopInfo.backingToken).safeTransfer(address(pool), backingTokensOwed);
+
+        emit LoopExecuted(
+            address(this),
+            loopInfo.exposureToken,
+            loopInfo.backingToken,
+            loopInfo.exposureAmount,
+            loopInfo.initialBackingAmount
+        );
+    }
+
+    function adjustBackingTokenPosition(
+        uint256 repayAmount,
+        uint256 borrowAmount,
+        address morpho,
+        MarketParams memory morphoMarketParams
+    ) internal {
+        if (repayAmount > borrowAmount) {
+            uint256 surplusAmount = repayAmount - borrowAmount;
+            IERC20(morphoMarketParams.loanToken).forceApprove(morpho, surplusAmount);
+            IMorpho(morpho).repay({
+                marketParams: morphoMarketParams,
+                assets: surplusAmount,
+                shares: 0,
+                onBehalf: address(this),
+                data: new bytes(0)
+            });
+        } else if (repayAmount < borrowAmount) {
+            IMorpho(morpho).borrow({
+                marketParams: morphoMarketParams,
+                assets: borrowAmount - repayAmount,
+                shares: 0,
+                onBehalf: address(this),
+                receiver: address(this)
+            });
+        }
+    }
+}

--- a/src/UnloopLong.sol
+++ b/src/UnloopLong.sol
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.27;
+
+import {SafeERC20, IERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
+import {IUniswapV3SwapCallback} from "v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol";
+import {IUniswapV3Pool} from "v3-core/contracts/interfaces/IUniswapV3Pool.sol";
+import {SafeCast} from "v3-core/contracts/libraries/SafeCast.sol";
+
+import {QuarkScript} from "quark-core/src/QuarkScript.sol";
+
+import {SharesMathLib} from "src/vendor/morpho_blue_periphery/SharesMathLib.sol";
+
+import {PoolAddress} from "./vendor/uniswap-v3-periphery/PoolAddress.sol";
+import {UniswapFactoryAddress} from "./lib/UniswapFactoryAddress.sol";
+
+import {IMorpho, MarketParams, Position} from "src/interfaces/IMorpho.sol";
+
+/**
+ * @title Unloop Long
+ * @notice Implements an unloop long strategy on Morpho using Uniswap V3 flash swap as liquidity
+ * @author Legend Labs, Inc.
+ */
+contract UnloopLong is IUniswapV3SwapCallback, QuarkScript {
+    using SafeERC20 for IERC20;
+    using SafeCast for uint256;
+
+    error InvalidCaller();
+    error BadData();
+    error SwapTooExpensive(address token, uint256 minAmountOut, uint256 actualAmountOut);
+    error InvalidMarketParams();
+
+    event UnloopExecuted(
+        address indexed sender, address indexed exposureToken, address indexed backingToken, uint256 exposureAmount
+    );
+
+    /// @dev The minimum value that can be returned from #getSqrtRatioAtTick. Equivalent to getSqrtRatioAtTick(MIN_TICK)
+    /// Reference: https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/TickMath.sol
+    uint160 internal constant MIN_SQRT_RATIO = 4295128739;
+    /// @dev The maximum value that can be returned from #getSqrtRatioAtTick. Equivalent to getSqrtRatioAtTick(MAX_TICK)
+    /// Reference: https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/TickMath.sol
+    uint160 internal constant MAX_SQRT_RATIO = 1461446703485210103287273052203988822378723970342;
+
+    /// @notice Stores details about the unlooping operation
+    struct UnloopInfo {
+        address exposureToken;
+        address backingToken;
+        // Uniswap pool fee
+        uint24 poolFee;
+        // The amount of exposure tokens to reduce from the loop position
+        uint256 exposureAmount;
+        // Minimum amount of backing tokens that should be received for the exposure amount
+        uint256 minSwapBackingAmount;
+    }
+
+    /// @notice Input for unloop long when interacting with the callback in a Uniswap V3 flash swap
+    struct UnloopLongInput {
+        PoolAddress.PoolKey poolKey;
+        UnloopInfo unloopInfo;
+        address morpho;
+        MarketParams morphoMarketParams;
+    }
+
+    /**
+     * @notice Executes an unlooping long strategy via a flash swap (if necessary)
+     * @param morpho Address of the Morpho contract to interact with
+     * @param morphoMarketParams The parameters for the Morpho market to unloop in
+     * @param unloopInfo Information for executing the unloop
+     */
+    function unloop(address morpho, MarketParams memory morphoMarketParams, UnloopInfo memory unloopInfo) external {
+        allowCallback();
+
+        if (
+            (
+                morphoMarketParams.collateralToken != unloopInfo.exposureToken
+                    || morphoMarketParams.loanToken != unloopInfo.backingToken
+            )
+        ) {
+            revert InvalidMarketParams();
+        }
+        // When unlooping long, we swap the exposure token to repay the backing token
+        address tokenIn = unloopInfo.exposureToken;
+        address tokenOut = unloopInfo.backingToken;
+        uint256 amountIn;
+        if (unloopInfo.exposureAmount == type(uint256).max) {
+            amountIn = IMorpho(morpho).position(marketId(morphoMarketParams), address(this)).collateral;
+        } else {
+            amountIn = unloopInfo.exposureAmount;
+        }
+
+        bool zeroForOne = tokenIn < tokenOut;
+        PoolAddress.PoolKey memory poolKey = PoolAddress.getPoolKey(tokenIn, tokenOut, unloopInfo.poolFee);
+        IUniswapV3Pool(PoolAddress.computeAddress(UniswapFactoryAddress.getAddress(), poolKey)).swap(
+            address(this),
+            zeroForOne,
+            // Positive value for exact in
+            amountIn.toInt256(),
+            zeroForOne ? MIN_SQRT_RATIO + 1 : MAX_SQRT_RATIO - 1,
+            abi.encode(
+                UnloopLongInput({
+                    poolKey: poolKey,
+                    unloopInfo: unloopInfo,
+                    morpho: morpho,
+                    morphoMarketParams: morphoMarketParams
+                })
+            )
+        );
+    }
+
+    /**
+     * @notice Callback function for Uniswap flash swap
+     * @param amount0Delta Amount of token0 owed (only need to repay positive value)
+     * @param amount1Delta Amount of token1 owed (only need to repay positive value)
+     * @param data Encoded UnloopLongInput data passed from UniswapV3Pool.swap()
+     */
+    function uniswapV3SwapCallback(int256 amount0Delta, int256 amount1Delta, bytes calldata data) external {
+        disallowCallback();
+
+        UnloopLongInput memory input = abi.decode(data, (UnloopLongInput));
+        UnloopInfo memory unloopInfo = input.unloopInfo;
+        IUniswapV3Pool pool =
+            IUniswapV3Pool(PoolAddress.computeAddress(UniswapFactoryAddress.getAddress(), input.poolKey));
+        if (msg.sender != address(pool)) {
+            revert InvalidCaller();
+        }
+
+        uint256 backingTokensReceived = amount0Delta < 0 ? uint256(-amount0Delta) : uint256(-amount1Delta);
+        uint256 exposureTokensOwed = amount0Delta > 0 ? uint256(amount0Delta) : uint256(amount1Delta);
+        if (backingTokensReceived < unloopInfo.minSwapBackingAmount) {
+            revert SwapTooExpensive(unloopInfo.backingToken, unloopInfo.minSwapBackingAmount, backingTokensReceived);
+        }
+
+        if (unloopInfo.exposureAmount == type(uint256).max) {
+            IERC20(input.morphoMarketParams.loanToken).forceApprove(input.morpho, type(uint256).max);
+            IMorpho(input.morpho).repay({
+                marketParams: input.morphoMarketParams,
+                assets: 0,
+                shares: IMorpho(input.morpho).position(marketId(input.morphoMarketParams), address(this)).borrowShares,
+                onBehalf: address(this),
+                data: new bytes(0)
+            });
+            IERC20(input.morphoMarketParams.loanToken).forceApprove(input.morpho, 0);
+        } else {
+            IERC20(input.morphoMarketParams.loanToken).forceApprove(input.morpho, backingTokensReceived);
+            IMorpho(input.morpho).repay({
+                marketParams: input.morphoMarketParams,
+                assets: backingTokensReceived,
+                shares: 0,
+                onBehalf: address(this),
+                data: new bytes(0)
+            });
+        }
+        IMorpho(input.morpho).withdrawCollateral({
+            marketParams: input.morphoMarketParams,
+            assets: exposureTokensOwed,
+            onBehalf: address(this),
+            receiver: address(this)
+        });
+
+        // Attempt to pay back amount owed after execution
+        IERC20(unloopInfo.exposureToken).safeTransfer(address(pool), exposureTokensOwed);
+
+        emit UnloopExecuted(address(this), unloopInfo.exposureToken, unloopInfo.backingToken, unloopInfo.exposureAmount);
+    }
+
+    // Helper function to convert MarketParams to bytes32 Id
+    // Reference: https://github.com/morpho-org/morpho-blue/blob/731e3f7ed97cf15f8fe00b86e4be5365eb3802ac/src/libraries/MarketParamsLib.sol
+    function marketId(MarketParams memory params) public pure returns (bytes32 marketParamsId) {
+        assembly ("memory-safe") {
+            marketParamsId := keccak256(params, 160)
+        }
+    }
+}

--- a/test/LoopLong.t.sol
+++ b/test/LoopLong.t.sol
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.27;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+import "forge-std/StdUtils.sol";
+
+import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
+
+import {CodeJar} from "codejar/src/CodeJar.sol";
+
+import {QuarkWallet} from "quark-core/src/QuarkWallet.sol";
+import {QuarkNonceManager} from "quark-core/src/QuarkNonceManager.sol";
+
+import {QuarkWalletProxyFactory} from "quark-proxy/src/QuarkWalletProxyFactory.sol";
+
+import {PoolAddress} from "src/vendor/uniswap-v3-periphery/PoolAddress.sol";
+import {SharesMathLib} from "src/vendor/morpho_blue_periphery/SharesMathLib.sol";
+
+import {LoopLong} from "src/LoopLong.sol";
+import {IMorpho, MarketParams, Position} from "src/interfaces/IMorpho.sol";
+
+import {Counter} from "./lib/Counter.sol";
+
+import {YulHelper} from "./lib/YulHelper.sol";
+import {SignatureHelper} from "./lib/SignatureHelper.sol";
+import {QuarkOperationHelper, ScriptType} from "./lib/QuarkOperationHelper.sol";
+
+import {IComet} from "src/interfaces/IComet.sol";
+
+contract LoopLongTest is Test {
+    event LoopExecuted(
+        address indexed sender,
+        address indexed exposureToken,
+        address indexed backingToken,
+        uint256 exposureAmount,
+        uint256 backingAmount
+    );
+
+    QuarkWalletProxyFactory public factory;
+    // For signature to QuarkWallet
+    uint256 alicePrivateKey = 0xa11ce;
+    address alice = vm.addr(alicePrivateKey);
+
+    // Contracts address on mainnet
+    address constant morpho = 0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb;
+    // Params for market at https://legacy.morpho.org/market?id=0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49&network=mainnet
+    address constant adaptiveCurveIrm = 0x870aC11D48B15DB9a138Cf899d20F13F79Ba00BC;
+    address constant WBTC_USDC_ORACLE = 0xDddd770BADd886dF3864029e4B377B5F6a2B6b83;
+    // Price from oracle at block is: 838255374224381093797298580131002978024
+    uint256 constant WBTC_USDC_PRICE = 83_825;
+    address constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address constant WBTC = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
+    MarketParams WBTC_USDC_MARKET_PARAMS = MarketParams(USDC, WBTC, WBTC_USDC_ORACLE, adaptiveCurveIrm, 0.86e18);
+
+    bytes loop = new YulHelper().getCode("LoopLong.sol/LoopLong.json");
+    address loopAddress;
+
+    function setUp() public {
+        vm.createSelectFork(
+            vm.envString("MAINNET_RPC_URL"),
+            22047554 // 2025-03-14 08:38:23 UTC
+        );
+        factory = new QuarkWalletProxyFactory(address(new QuarkWallet(new CodeJar(), new QuarkNonceManager())));
+        loopAddress = QuarkWallet(payable(factory.walletImplementation())).codeJar().saveCode(loop);
+    }
+
+    function testLoopLong() public {
+        vm.pauseGasMetering();
+        QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));
+
+        // Set up some funds for test
+        uint256 startingUSDCAmount = 1_000e6;
+        deal(USDC, address(wallet), startingUSDCAmount);
+
+        // Loop $1000 of USDC to get ~$3000 of WBTC exposure
+        uint256 wbtcExposure =
+            enterLoopPosition({wallet: wallet, startingUSDCAmount: startingUSDCAmount, loopFactor: 3});
+
+        // Verify that the user is now supplying WBTC and borrowing USDC from Morpho
+        assertEq(IERC20(USDC).balanceOf(address(wallet)), 0);
+        assertLoopPosition({wallet: wallet, wbtcLongExposure: wbtcExposure, usdcShortExposure: 2 * startingUSDCAmount});
+    }
+
+    function testLoopLongAdjustPosition() public {
+        vm.pauseGasMetering();
+        QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));
+
+        // Set up some funds for test
+        uint256 startingUSDCAmount = 1_000e6;
+        uint256 extraBackingAmount = 1_000e6;
+        deal(USDC, address(wallet), startingUSDCAmount + extraBackingAmount);
+
+        // 1. Loop $1000 of USDC to get ~$3000 of WBTC exposure
+        uint256 wbtcExposure =
+            enterLoopPosition({wallet: wallet, startingUSDCAmount: startingUSDCAmount, loopFactor: 3});
+
+        assertEq(IERC20(USDC).balanceOf(address(wallet)), extraBackingAmount);
+        assertLoopPosition({wallet: wallet, wbtcLongExposure: wbtcExposure, usdcShortExposure: 2 * startingUSDCAmount});
+
+        // 2. Add $1000 of backing token to the position
+        enterLoopPosition({wallet: wallet, startingUSDCAmount: startingUSDCAmount, loopFactor: 0});
+
+        // Verify that the user is now supplying WBTC and borrowing USDC from Morpho
+        assertEq(IERC20(USDC).balanceOf(address(wallet)), 0);
+        assertLoopPosition({
+            wallet: wallet,
+            wbtcLongExposure: wbtcExposure,
+            usdcShortExposure: 2 * startingUSDCAmount - extraBackingAmount
+        });
+
+        // 3. Increase WBTC exposure by $1000
+        uint256 extraWBTCExposure = extraBackingAmount * 1e8 / WBTC_USDC_PRICE / 1e6;
+        enterLoopPosition({
+            wallet: wallet,
+            exposureAmount: extraWBTCExposure,
+            maxSwapBackingAmount: extraBackingAmount * 1.005e18 / 1e18,
+            startingUSDCAmount: 0
+        });
+
+        // Verify that the user is now supplying WBTC and borrowing USDC from Morpho
+        assertEq(IERC20(USDC).balanceOf(address(wallet)), 0);
+        assertLoopPosition({
+            wallet: wallet,
+            wbtcLongExposure: wbtcExposure + extraWBTCExposure,
+            usdcShortExposure: 2 * startingUSDCAmount - extraBackingAmount + extraBackingAmount
+        });
+    }
+
+    function testRevertsForSwapTooExpensiveLoopingLong() public {
+        vm.pauseGasMetering();
+        QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));
+
+        // Set up some funds for test
+        uint256 startingUSDCAmount = 1_000e6;
+        deal(USDC, address(wallet), startingUSDCAmount);
+
+        // Loop $1000 of USDC to get ~$3000 of WBTC exposure
+        uint256 wbtcExposure = 3 * startingUSDCAmount * 1e8 / WBTC_USDC_PRICE / 1e6;
+        // Should be at least 3x the starting USDC amount, but we set it as 2x here to force a revert
+        uint256 maxSwapBackingAmount = 2 * startingUSDCAmount;
+        LoopLong.LoopInfo memory loopInfo = LoopLong.LoopInfo({
+            exposureToken: WBTC,
+            backingToken: USDC,
+            poolFee: 500,
+            exposureAmount: wbtcExposure,
+            maxSwapBackingAmount: maxSwapBackingAmount,
+            initialBackingAmount: startingUSDCAmount
+        });
+
+        QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
+            wallet,
+            loop,
+            abi.encodeWithSelector(LoopLong.loop.selector, morpho, WBTC_USDC_MARKET_PARAMS, loopInfo),
+            ScriptType.ScriptAddress
+        );
+        bytes memory signature = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+        vm.resumeGasMetering();
+        vm.expectRevert(
+            abi.encodeWithSelector(LoopLong.SwapTooExpensive.selector, USDC, maxSwapBackingAmount, 3_005_547_356)
+        );
+        wallet.executeQuarkOperation(op, signature);
+    }
+
+    function testInvalidCaller() public {
+        vm.pauseGasMetering();
+        QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));
+
+        // Try to invoke callback directly, expect revert with invalid caller
+        LoopLong.LoopLongInput memory input;
+        input.poolKey = PoolAddress.getPoolKey(WBTC, USDC, 500);
+        QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
+            wallet,
+            loop,
+            abi.encodeWithSelector(LoopLong.uniswapV3SwapCallback.selector, 1e6, 1e6, abi.encode(input)),
+            ScriptType.ScriptAddress
+        );
+        bytes memory signature = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+        vm.expectRevert(abi.encodeWithSelector(LoopLong.InvalidCaller.selector));
+        vm.resumeGasMetering();
+        wallet.executeQuarkOperation(op, signature);
+    }
+
+    /* ========== Helpers ========== */
+
+    function enterLoopPosition(QuarkWallet wallet, uint256 startingUSDCAmount, uint256 loopFactor)
+        internal
+        returns (uint256)
+    {
+        uint256 wbtcExposure = loopFactor * startingUSDCAmount * 1e8 / WBTC_USDC_PRICE / 1e6;
+        // We add a 0.5% buffer to account for price impact and swap fees
+        uint256 maxSwapBackingAmount = loopFactor * startingUSDCAmount * 1.005e18 / 1e18;
+        return enterLoopPosition({
+            wallet: wallet,
+            exposureAmount: wbtcExposure,
+            maxSwapBackingAmount: maxSwapBackingAmount,
+            startingUSDCAmount: startingUSDCAmount
+        });
+    }
+
+    function enterLoopPosition(
+        QuarkWallet wallet,
+        uint256 exposureAmount,
+        uint256 maxSwapBackingAmount,
+        uint256 startingUSDCAmount
+    ) internal returns (uint256) {
+        vm.pauseGasMetering();
+        LoopLong.LoopInfo memory loopInfo = LoopLong.LoopInfo({
+            exposureToken: WBTC,
+            backingToken: USDC,
+            poolFee: 500,
+            exposureAmount: exposureAmount,
+            maxSwapBackingAmount: maxSwapBackingAmount,
+            initialBackingAmount: startingUSDCAmount
+        });
+
+        QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
+            wallet,
+            loop,
+            abi.encodeWithSelector(LoopLong.loop.selector, morpho, WBTC_USDC_MARKET_PARAMS, loopInfo),
+            ScriptType.ScriptAddress
+        );
+        bytes memory signature = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+        vm.resumeGasMetering();
+        vm.expectEmit(true, true, true, true);
+        emit LoopExecuted(address(wallet), WBTC, USDC, exposureAmount, startingUSDCAmount);
+        wallet.executeQuarkOperation(op, signature);
+
+        return exposureAmount;
+    }
+
+    function assertLoopPosition(QuarkWallet wallet, uint256 wbtcLongExposure, uint256 usdcShortExposure) internal {
+        uint256 maxDeltaPercentage = 0.01e18; // 1%
+        assertApproxEqRel(
+            IMorpho(morpho).position(marketId(WBTC_USDC_MARKET_PARAMS), address(wallet)).collateral,
+            wbtcLongExposure,
+            maxDeltaPercentage
+        );
+        (,, uint128 totalBorrowAssets, uint128 totalBorrowShares,,) =
+            IMorpho(morpho).market(marketId(WBTC_USDC_MARKET_PARAMS));
+        assertApproxEqRel(
+            SharesMathLib.toAssetsUp(
+                IMorpho(morpho).position(marketId(WBTC_USDC_MARKET_PARAMS), address(wallet)).borrowShares,
+                totalBorrowAssets,
+                totalBorrowShares
+            ),
+            usdcShortExposure,
+            maxDeltaPercentage
+        );
+    }
+
+    // Helper function to convert MarketParams to bytes32 Id
+    // Reference: https://github.com/morpho-org/morpho-blue/blob/731e3f7ed97cf15f8fe00b86e4be5365eb3802ac/src/libraries/MarketParamsLib.sol
+    function marketId(MarketParams memory params) public pure returns (bytes32 marketParamsId) {
+        assembly ("memory-safe") {
+            marketParamsId := keccak256(params, 160)
+        }
+    }
+}

--- a/test/UnloopLong.t.sol
+++ b/test/UnloopLong.t.sol
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: BSD-3-Clause
+pragma solidity 0.8.27;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+import "forge-std/StdUtils.sol";
+
+import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
+
+import {CodeJar} from "codejar/src/CodeJar.sol";
+
+import {QuarkWallet} from "quark-core/src/QuarkWallet.sol";
+import {QuarkNonceManager} from "quark-core/src/QuarkNonceManager.sol";
+
+import {QuarkWalletProxyFactory} from "quark-proxy/src/QuarkWalletProxyFactory.sol";
+
+import {PoolAddress} from "src/vendor/uniswap-v3-periphery/PoolAddress.sol";
+import {SharesMathLib} from "src/vendor/morpho_blue_periphery/SharesMathLib.sol";
+
+import {LoopLong} from "src/LoopLong.sol";
+import {UnloopLong} from "src/UnloopLong.sol";
+
+import {IMorpho, MarketParams, Position} from "src/interfaces/IMorpho.sol";
+
+import {YulHelper} from "./lib/YulHelper.sol";
+import {SignatureHelper} from "./lib/SignatureHelper.sol";
+import {QuarkOperationHelper, ScriptType} from "./lib/QuarkOperationHelper.sol";
+
+contract UnloopLongTest is Test {
+    event UnloopExecuted(
+        address indexed sender, address indexed exposureToken, address indexed backingToken, uint256 exposureAmount
+    );
+
+    QuarkWalletProxyFactory public factory;
+    // For signature to QuarkWallet
+    uint256 alicePrivateKey = 0xa11ce;
+    address alice = vm.addr(alicePrivateKey);
+
+    // Contracts address on mainnet
+    address constant morpho = 0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb;
+    // Params for market at https://legacy.morpho.org/market?id=0x3a85e619751152991742810df6ec69ce473daef99e28a64ab2340d7b7ccfee49&network=mainnet
+    address constant adaptiveCurveIrm = 0x870aC11D48B15DB9a138Cf899d20F13F79Ba00BC;
+    address constant WBTC_USDC_ORACLE = 0xDddd770BADd886dF3864029e4B377B5F6a2B6b83;
+    // Price from oracle at block is: 838255374224381093797298580131002978024
+    uint256 constant WBTC_USDC_PRICE = 83_825;
+    address constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address constant WBTC = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
+    MarketParams WBTC_USDC_MARKET_PARAMS = MarketParams(USDC, WBTC, WBTC_USDC_ORACLE, adaptiveCurveIrm, 0.86e18);
+
+    bytes loop = new YulHelper().getCode("LoopLong.sol/LoopLong.json");
+    bytes unloop = new YulHelper().getCode("UnloopLong.sol/UnloopLong.json");
+    address loopAddress;
+    address unloopAddress;
+
+    function setUp() public {
+        vm.createSelectFork(
+            vm.envString("MAINNET_RPC_URL"),
+            22047554 // 2025-03-14 08:38:23 UTC
+        );
+        factory = new QuarkWalletProxyFactory(address(new QuarkWallet(new CodeJar(), new QuarkNonceManager())));
+        loopAddress = QuarkWallet(payable(factory.walletImplementation())).codeJar().saveCode(loop);
+        unloopAddress = QuarkWallet(payable(factory.walletImplementation())).codeJar().saveCode(unloop);
+    }
+
+    function testUnloopLong() public {
+        vm.pauseGasMetering();
+        QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));
+
+        // Set up some funds for test
+        uint256 startingUSDCAmount = 1_000e6;
+        deal(USDC, address(wallet), startingUSDCAmount);
+
+        // Loop $1000 of USDC to get ~$3000 of WBTC exposure
+        uint256 wbtcExposure =
+            enterLoopPosition({wallet: wallet, startingUSDCAmount: startingUSDCAmount, loopFactor: 3});
+
+        // Verify that the user is now supplying WBTC and borrowing USDC from Morpho
+        assertEq(IERC20(USDC).balanceOf(address(wallet)), 0);
+        assertLoopPosition({wallet: wallet, wbtcLongExposure: wbtcExposure, usdcShortExposure: 2 * startingUSDCAmount});
+
+        // Exit ~$1500 of WBTC exposure
+        uint256 exposureToReduce = wbtcExposure * 0.5e18 / 1e18;
+        uint256 minSwapBackingAmount = exitLoopPosition({wallet: wallet, exposureToReduce: exposureToReduce});
+
+        assertEq(IERC20(USDC).balanceOf(address(wallet)), 0);
+        assertLoopPosition({
+            wallet: wallet,
+            wbtcLongExposure: wbtcExposure - exposureToReduce,
+            usdcShortExposure: 2 * startingUSDCAmount - minSwapBackingAmount
+        });
+    }
+
+    function testUnloopLongMax() public {
+        vm.pauseGasMetering();
+        QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));
+
+        // Set up some funds for test
+        uint256 startingUSDCAmount = 1_000e6;
+        deal(USDC, address(wallet), startingUSDCAmount);
+
+        // Loop $1000 of USDC to get ~$3000 of WBTC exposure
+        uint256 wbtcExposure =
+            enterLoopPosition({wallet: wallet, startingUSDCAmount: startingUSDCAmount, loopFactor: 3});
+
+        // Verify that the user is now supplying WBTC and borrowing USDC from Morpho
+        assertEq(IERC20(USDC).balanceOf(address(wallet)), 0);
+        assertLoopPosition({wallet: wallet, wbtcLongExposure: wbtcExposure, usdcShortExposure: 2 * startingUSDCAmount});
+
+        // Exit the entire exposure
+        exitLoopPosition({wallet: wallet, exposureToReduce: type(uint256).max});
+
+        // The wallet should have the starting USDC amount (within a 0.5% tolerance) now that the position is fully unlooped
+        assertApproxEqRel(IERC20(USDC).balanceOf(address(wallet)), startingUSDCAmount, 0.005e18);
+        assertLoopPosition({wallet: wallet, wbtcLongExposure: 0, usdcShortExposure: 0});
+    }
+
+    function testRevertsForSwapTooExpensiveUnloopingLong() public {
+        vm.pauseGasMetering();
+        QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));
+
+        // Set up some funds for test
+        uint256 startingUSDCAmount = 1_000e6;
+        deal(USDC, address(wallet), startingUSDCAmount);
+
+        // Unloop $1000 of WBTC exposure
+        uint256 wbtcExposure = startingUSDCAmount * 1e8 / WBTC_USDC_PRICE / 1e6;
+        // Should be ~$1000 of USDC, but we set it higher to force a revert
+        uint256 minSwapBackingAmount = 1_200e6;
+        UnloopLong.UnloopInfo memory unloopInfo = UnloopLong.UnloopInfo({
+            exposureToken: WBTC,
+            backingToken: USDC,
+            poolFee: 500,
+            exposureAmount: wbtcExposure,
+            minSwapBackingAmount: minSwapBackingAmount
+        });
+
+        QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
+            wallet,
+            unloop,
+            abi.encodeWithSelector(UnloopLong.unloop.selector, morpho, WBTC_USDC_MARKET_PARAMS, unloopInfo),
+            ScriptType.ScriptAddress
+        );
+        bytes memory signature = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+        vm.resumeGasMetering();
+        vm.expectRevert(
+            abi.encodeWithSelector(UnloopLong.SwapTooExpensive.selector, USDC, minSwapBackingAmount, 1_000_759_942)
+        );
+        wallet.executeQuarkOperation(op, signature);
+    }
+
+    function testInvalidCaller() public {
+        vm.pauseGasMetering();
+        QuarkWallet wallet = QuarkWallet(factory.create(alice, address(0)));
+
+        // Try to invoke callback directly, expect revert with invalid caller
+        UnloopLong.UnloopLongInput memory input;
+        input.poolKey = PoolAddress.getPoolKey(WBTC, USDC, 500);
+        QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
+            wallet,
+            unloop,
+            abi.encodeWithSelector(UnloopLong.uniswapV3SwapCallback.selector, 1e6, 1e6, abi.encode(input)),
+            ScriptType.ScriptAddress
+        );
+        bytes memory signature = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+        vm.expectRevert(abi.encodeWithSelector(UnloopLong.InvalidCaller.selector));
+        vm.resumeGasMetering();
+        wallet.executeQuarkOperation(op, signature);
+    }
+
+    /* ========== Helpers ========== */
+
+    function enterLoopPosition(QuarkWallet wallet, uint256 startingUSDCAmount, uint256 loopFactor)
+        internal
+        returns (uint256)
+    {
+        vm.pauseGasMetering();
+        uint256 wbtcExposure = loopFactor * startingUSDCAmount * 1e8 / WBTC_USDC_PRICE / 1e6;
+        // We add a 0.5% buffer to account for price impact and swap fees
+        uint256 maxSwapBackingAmount = loopFactor * startingUSDCAmount * 1.005e18 / 1e18;
+        LoopLong.LoopInfo memory loopInfo = LoopLong.LoopInfo({
+            exposureToken: WBTC,
+            backingToken: USDC,
+            poolFee: 500,
+            exposureAmount: wbtcExposure,
+            maxSwapBackingAmount: maxSwapBackingAmount,
+            initialBackingAmount: startingUSDCAmount
+        });
+
+        QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
+            wallet,
+            loop,
+            abi.encodeWithSelector(LoopLong.loop.selector, morpho, WBTC_USDC_MARKET_PARAMS, loopInfo),
+            ScriptType.ScriptAddress
+        );
+        bytes memory signature = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+        vm.resumeGasMetering();
+        wallet.executeQuarkOperation(op, signature);
+
+        return wbtcExposure;
+    }
+
+    function exitLoopPosition(QuarkWallet wallet, uint256 exposureToReduce) internal returns (uint256) {
+        vm.pauseGasMetering();
+        // We add a 0.5% buffer to account for price impact and swap fees
+        uint256 minSwapBackingAmount =
+            exposureToReduce == type(uint256).max ? 0 : exposureToReduce * WBTC_USDC_PRICE * 0.995e6 / 1e8;
+        UnloopLong.UnloopInfo memory unloopInfo = UnloopLong.UnloopInfo({
+            exposureToken: WBTC,
+            backingToken: USDC,
+            poolFee: 500,
+            exposureAmount: exposureToReduce,
+            minSwapBackingAmount: minSwapBackingAmount
+        });
+
+        QuarkWallet.QuarkOperation memory op = new QuarkOperationHelper().newBasicOpWithCalldata(
+            wallet,
+            unloop,
+            abi.encodeWithSelector(UnloopLong.unloop.selector, morpho, WBTC_USDC_MARKET_PARAMS, unloopInfo),
+            ScriptType.ScriptAddress
+        );
+        bytes memory signature = new SignatureHelper().signOp(alicePrivateKey, wallet, op);
+        vm.resumeGasMetering();
+        vm.expectEmit(true, true, true, true);
+        emit UnloopExecuted(address(wallet), WBTC, USDC, exposureToReduce);
+        wallet.executeQuarkOperation(op, signature);
+
+        return minSwapBackingAmount;
+    }
+
+    function assertLoopPosition(QuarkWallet wallet, uint256 wbtcLongExposure, uint256 usdcShortExposure) internal {
+        uint256 maxDeltaPercentage = 0.01e18; // 1%
+        assertApproxEqRel(
+            IMorpho(morpho).position(marketId(WBTC_USDC_MARKET_PARAMS), address(wallet)).collateral,
+            wbtcLongExposure,
+            maxDeltaPercentage
+        );
+        (,, uint128 totalBorrowAssets, uint128 totalBorrowShares,,) =
+            IMorpho(morpho).market(marketId(WBTC_USDC_MARKET_PARAMS));
+        assertApproxEqRel(
+            SharesMathLib.toAssetsUp(
+                IMorpho(morpho).position(marketId(WBTC_USDC_MARKET_PARAMS), address(wallet)).borrowShares,
+                totalBorrowAssets,
+                totalBorrowShares
+            ),
+            usdcShortExposure,
+            maxDeltaPercentage
+        );
+    }
+
+    // Helper function to convert MarketParams to bytes32 Id
+    // Reference: https://github.com/morpho-org/morpho-blue/blob/731e3f7ed97cf15f8fe00b86e4be5365eb3802ac/src/libraries/MarketParamsLib.sol
+    function marketId(MarketParams memory params) public pure returns (bytes32 marketParamsId) {
+        assembly ("memory-safe") {
+            marketParamsId := keccak256(params, 160)
+        }
+    }
+}


### PR DESCRIPTION
This PR implements `LoopLong` and `UnloopLong`, two Legend scripts that enables a user to loop into or unloop a lending position on Morpho. The liquidity for looping/unlooping the position is taken from Uniswap v3 using a flash swap.

When thinking about a loop/unloop, there is the `exposureToken` and the `backingToken`. The `exposureToken` is what the user intends to increase/decrease their long exposure in. The `backingToken` is the token that is borrowed from Morpho and swapped into the exposure token. In a typical scenario where one wants to get 3x exposure on BTC with USDC, they could put $1k of USDC to get $3k of BTC exposure.